### PR TITLE
Add podLabels value for extra pod labels (#17)

### DIFF
--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
 {{- end }}
       labels:
         {{- include "s3proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -39,6 +39,9 @@ serviceAccount:
 # -- Annotations to add to the pod
 podAnnotations: {}
 
+# -- Extra labels to add to the pod (merged with the chart's selector labels)
+podLabels: {}
+
 # -- Pod security context
 podSecurityContext: {}
 


### PR DESCRIPTION
## What

Adds a `podLabels` value so users can attach extra labels to the S3Proxy pods, addressing #17.

## Why

Issue #17 asks for the ability to add custom pod labels "so we can add extra labels for custom configs." The chart currently only stamps the standard selector labels (`app.kubernetes.io/name`, `app.kubernetes.io/instance`) onto the pod template, with no hook for user-defined labels. This is the standard Helm-chart affordance (matches `podAnnotations`, which already exists).
