### PR TITLE
[DND-1417] Add CI: lint, render-diff, and kind functional tests

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -1,0 +1,102 @@
+name: Functional Test (kind)
+
+# Installs the chart into an ephemeral kind cluster (thrown away with the runner)
+# alongside lightweight mock backends, then performs a real S3 round-trip through
+# s3proxy. Public repo → GitHub-hosted runner + kind, no cluster credentials, so
+# it is safe to run on every PR (including forks).
+#
+# Backend coverage:
+#   s3                      -> MinIO mock, HARD GATE (full S3 round-trip).
+#   filesystem / transient  -> NON-BLOCKING (soft_fail): the chart does not emit
+#                              jclouds.identity/jclouds.credential for local
+#                              backends, so s3proxy refuses to start
+#                              ("Properties file must contain: jclouds.identity
+#                              and jclouds.credential"). Tracked in DND-1442.
+#   azureblob               -> Azurite mock, NON-BLOCKING (soft_fail) until DND-1416
+#                              fixes the endpoint property (jclouds.azureblob.endpoint
+#                              -> jclouds.endpoint); the failing round-trip is the
+#                              functional test demonstrably catching that regression.
+# Each soft_fail leg auto-goes-green once its bug is fixed.
+# gcs/b2/openstack-swift/rackspace are render-only (covered by lint-render + helm-diff):
+# gcs has no jclouds.endpoint override in the chart, and the others have no
+# lightweight in-cluster emulator.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - charts/s3proxy/**
+      - ci/functional/**
+      - test-values/**
+      - .github/workflows/functional-test.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  functional:
+    name: functional (${{ matrix.backend }})
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.soft_fail == true }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: s3
+            values: ci/functional/values/s3.yaml
+            mock: ci/functional/mocks/minio.yaml
+          - backend: filesystem
+            values: ci/functional/values/filesystem.yaml
+            soft_fail: true
+          - backend: transient
+            values: ci/functional/values/transient.yaml
+            soft_fail: true
+          - backend: azureblob
+            values: ci/functional/values/azureblob.yaml
+            mock: ci/functional/mocks/azurite.yaml
+            soft_fail: true
+    env:
+      NAMESPACE: s3proxy-test
+      RELEASE: s3proxy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.19.2
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      - name: Create namespace
+        run: kubectl create namespace "${NAMESPACE}"
+
+      - name: Deploy mock backend (${{ matrix.backend }})
+        if: matrix.mock
+        run: |
+          kubectl apply -n "${NAMESPACE}" -f "${{ matrix.mock }}"
+          kubectl -n "${NAMESPACE}" rollout status deploy --timeout=180s
+
+      - name: Install s3proxy
+        run: |
+          helm upgrade --install "${RELEASE}" charts/s3proxy \
+            -n "${NAMESPACE}" \
+            --values "${{ matrix.values }}" \
+            --wait --timeout 5m
+
+      - name: Smoke test (S3 round-trip)
+        run: |
+          chmod +x ci/functional/smoke-test.sh
+          ci/functional/smoke-test.sh "${RELEASE}" "${NAMESPACE}" 9000 test-access-key test-secret-key
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n "${NAMESPACE}" get all || true
+          kubectl -n "${NAMESPACE}" describe pods || true
+          kubectl -n "${NAMESPACE}" logs -l app.kubernetes.io/name=s3proxy --all-containers --tail=300 || true
+          kubectl -n "${NAMESPACE}" get events --sort-by=.lastTimestamp || true

--- a/.github/workflows/helm-diff.yaml
+++ b/.github/workflows/helm-diff.yaml
@@ -3,8 +3,12 @@ name: Helm Render Diff
 # Informational: renders every test-values scenario on both the PR base and head,
 # diffs the resulting Kubernetes manifests, and posts a sticky PR comment so
 # reviewers can see exactly what a change does to the rendered output.
-# Runs on GitHub-hosted runners with only public actions (public repo, no secrets
-# beyond the automatic GITHUB_TOKEN). Never fails the PR.
+#
+# This ports the diff/report logic from comet-ml/gha-tools helm/helm-diff, but
+# runs self-contained on GitHub-hosted runners with public actions — that private
+# action runs on the self-hosted `helm` runner and can't be used from a public
+# repo (fork PRs can't pull a private action, and self-hosted runners must not run
+# fork code). Never fails the PR (the hard gate is lint-render.yaml).
 
 on:
   pull_request:
@@ -14,9 +18,14 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 env:
   KUBE_VERSION: "1.29.0"
+  CHART_PATH: charts/s3proxy
+  # Match gha-tools helm-diff defaults so output is consistent with our other charts.
+  RELEASE_NAME: release
+  NAMESPACE: default
 
 jobs:
   render-diff:
@@ -26,13 +35,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: head
+          path: pr-repo
 
       - name: Checkout base
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          path: base
+          path: base-repo
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -42,74 +51,169 @@ jobs:
       - name: Render and diff
         run: |
           set -uo pipefail
+
+          # render <repo-dir> <values-relpath> <out-file>
+          # Renders the chart if both the chart dir and the values file exist on
+          # that side; otherwise writes an empty baseline (mirrors gha-tools, so a
+          # values file that only exists on the PR shows up as fully added).
           render() {
-            # render <repo-dir> <values-relpath> <out-file>
             local dir="$1" vals="$2" out="$3"
-            if [ -f "${dir}/${vals}" ] && [ -d "${dir}/charts/s3proxy" ]
+            if [ -f "${dir}/${vals}" ] && [ -d "${dir}/${CHART_PATH}" ]
             then
-              helm template s3proxy "${dir}/charts/s3proxy" \
-                --values "${dir}/${vals}" \
-                --kube-version "${KUBE_VERSION}" > "$out" 2>"${out}.err" || {
-                  echo "render error for ${dir}/${vals}:"
-                  cat "${out}.err"
-                  : > "$out"
-                }
+              if ! helm template "${RELEASE_NAME}" "${dir}/${CHART_PATH}" \
+                    --namespace "${NAMESPACE}" \
+                    --values "${dir}/${vals}" \
+                    --kube-version "${KUBE_VERSION}" > "$out" 2>"${out}.err"
+              then
+                echo "⚠️ render error for ${dir}/${vals}:"
+                cat "${out}.err"
+                : > "$out"
+              fi
             else
               : > "$out"
             fi
           }
 
-          summary=diff-summary.md
-          echo "## 📊 Helm render diff (base vs PR)" > "$summary"
-          echo "" >> "$summary"
-          echo "_Rendered with Kubernetes ${KUBE_VERSION}. Informational only — this check never fails the PR._" >> "$summary"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          COMMENT_LIMIT=60000
 
-          changed=0
-          for f in head/test-values/*.yaml
+          # Union of scenario files across base and head, so a scenario removed in
+          # the PR (present on base, absent on head) still shows up as a deletion.
+          names="$(
+            { ls -1 pr-repo/test-values/*.yaml base-repo/test-values/*.yaml 2>/dev/null || true; } \
+              | xargs -r -n1 basename | sort -u
+          )"
+
+          # Two parts: a summary table (always small) and the detailed diffs.
+          table=/tmp/table.md
+          details=/tmp/details.md
+          {
+            echo "<!-- helm-render-diff -->"
+            echo "## 📊 Helm Render Diff Summary"
+            echo ""
+            echo "Chart \`${CHART_PATH}\` rendered with Kubernetes \`${KUBE_VERSION}\`. Informational only — this check never fails the PR."
+            echo ""
+            echo "| Values File | Chart Path | Changes | Status |"
+            echo "|-------------|------------|---------|--------|"
+          } > "$table"
+          echo "## 🔍 Detailed Changes" > "$details"
+
+          any_changes=0
+          while IFS= read -r name
           do
-            name="$(basename "$f")"
-            render head "test-values/${name}" "/tmp/head-${name}"
-            render base "test-values/${name}" "/tmp/base-${name}"
-            if ! diff -u "/tmp/base-${name}" "/tmp/head-${name}" > "/tmp/diff-${name}"
+            [ -n "$name" ] || continue
+            render pr-repo   "test-values/${name}" "/tmp/after-${name}"
+            render base-repo "test-values/${name}" "/tmp/before-${name}"
+
+            diff -u "/tmp/before-${name}" "/tmp/after-${name}" > "/tmp/diff-${name}" || true
+
+            if [ -s "/tmp/diff-${name}" ]
             then
-              changed=1
+              any_changes=1
+              # Additions/deletions, excluding the +++/--- file headers (as gha-tools does).
+              additions=$(grep '^+' "/tmp/diff-${name}" | grep -vc '^+++' || true)
+              deletions=$(grep '^-' "/tmp/diff-${name}" | grep -vc '^---' || true)
+              echo "| \`test-values/${name}\` | \`${CHART_PATH}\` | +${additions} -${deletions} | 🔄 **Changes Detected** ([summary](${RUN_URL})) |" >> "$table"
               {
                 echo ""
-                echo "<details><summary>🔄 <code>${name}</code></summary>"
+                echo "### 📝 Changes in \`${CHART_PATH}\` with \`test-values/${name}\`"
+                echo ""
+                echo "<details><summary>🔍 Click to view complete diff</summary>"
                 echo ""
                 echo '```diff'
                 cat "/tmp/diff-${name}"
                 echo '```'
                 echo ""
                 echo "</details>"
-              } >> "$summary"
+              } >> "$details"
+            else
+              echo "| \`test-values/${name}\` | \`${CHART_PATH}\` | - | ✅ No Changes |" >> "$table"
             fi
-          done
+          done <<< "$names"
 
-          if [ "$changed" -eq 0 ]
+          if [ "$any_changes" -eq 0 ]
           then
-            echo "" >> "$summary"
-            echo "_No rendered manifest changes across the test-values scenarios._" >> "$summary"
-          fi
-
-          # Always publish the full diff to the job summary.
-          cat "$summary" >> "$GITHUB_STEP_SUMMARY"
-
-          # Cap the PR comment to stay well under GitHub's 65536-char limit.
-          if [ "$(wc -c < "$summary")" -gt 60000 ]
-          then
-            head -c 60000 "$summary" > diff-comment.md
             {
               echo ""
-              echo "…diff truncated — see the full render diff in the workflow job summary."
-            } >> diff-comment.md
-          else
-            cp "$summary" diff-comment.md
+              echo "### 🎉 No changes detected in any of the tested configurations!"
+            } >> "$table"
           fi
 
-      - name: Post sticky comment
+          # Full report (table + detailed diffs) always goes to the job summary.
+          cat "$table" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$any_changes" -eq 1 ]
+          then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              cat "$details"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # PR comment: table + inline diffs when it fits, otherwise a slimmed
+          # table-only comment linking to the full diffs in the job summary
+          # (mirrors the self-hosted chart's behaviour on large diffs).
+          {
+            cat "$table"
+            if [ "$any_changes" -eq 1 ]
+            then
+              echo ""
+              echo "---"
+              echo ""
+              cat "$details"
+            fi
+          } > /tmp/comment-full.md
+
+          if [ "$(wc -c < /tmp/comment-full.md)" -le "$COMMENT_LIMIT" ]
+          then
+            cp /tmp/comment-full.md diff-comment.md
+          else
+            {
+              cat "$table"
+              echo ""
+              echo "---"
+              echo ""
+              echo "> ℹ️ Per-scenario diffs are omitted from this comment because the full render diff exceeds GitHub's comment size limit. See the complete diffs in the [workflow job summary](${RUN_URL})."
+            } > diff-comment.md
+          fi
+
+      # Match the repo's preview-readme.yaml convention: minimize (collapse) any
+      # previous render-diff comments as OUTDATED, then post a fresh one. Uses
+      # first-party actions/github-script (no third-party comment action).
+      # continue-on-error: fork PRs get a read-only token and cannot comment; the
+      # full diff is still available in the job summary.
+      - name: Minimize outdated diff comments and post the latest
         continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          header: helm-render-diff
-          path: diff-comment.md
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- helm-render-diff -->';
+            const body = fs.readFileSync('diff-comment.md', 'utf8');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            for (const comment of comments) {
+              if (comment.user.type === 'Bot' && comment.body.includes(marker)) {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      clientMutationId
+                    }
+                  }`,
+                  { id: comment.node_id },
+                );
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/helm-diff.yaml
+++ b/.github/workflows/helm-diff.yaml
@@ -1,0 +1,115 @@
+name: Helm Render Diff
+
+# Informational: renders every test-values scenario on both the PR base and head,
+# diffs the resulting Kubernetes manifests, and posts a sticky PR comment so
+# reviewers can see exactly what a change does to the rendered output.
+# Runs on GitHub-hosted runners with only public actions (public repo, no secrets
+# beyond the automatic GITHUB_TOKEN). Never fails the PR.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  KUBE_VERSION: "1.29.0"
+
+jobs:
+  render-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+
+      - name: Checkout base
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.19.2
+
+      - name: Render and diff
+        run: |
+          set -uo pipefail
+          render() {
+            # render <repo-dir> <values-relpath> <out-file>
+            local dir="$1" vals="$2" out="$3"
+            if [ -f "${dir}/${vals}" ] && [ -d "${dir}/charts/s3proxy" ]
+            then
+              helm template s3proxy "${dir}/charts/s3proxy" \
+                --values "${dir}/${vals}" \
+                --kube-version "${KUBE_VERSION}" > "$out" 2>"${out}.err" || {
+                  echo "render error for ${dir}/${vals}:"
+                  cat "${out}.err"
+                  : > "$out"
+                }
+            else
+              : > "$out"
+            fi
+          }
+
+          summary=diff-summary.md
+          echo "## 📊 Helm render diff (base vs PR)" > "$summary"
+          echo "" >> "$summary"
+          echo "_Rendered with Kubernetes ${KUBE_VERSION}. Informational only — this check never fails the PR._" >> "$summary"
+
+          changed=0
+          for f in head/test-values/*.yaml
+          do
+            name="$(basename "$f")"
+            render head "test-values/${name}" "/tmp/head-${name}"
+            render base "test-values/${name}" "/tmp/base-${name}"
+            if ! diff -u "/tmp/base-${name}" "/tmp/head-${name}" > "/tmp/diff-${name}"
+            then
+              changed=1
+              {
+                echo ""
+                echo "<details><summary>🔄 <code>${name}</code></summary>"
+                echo ""
+                echo '```diff'
+                cat "/tmp/diff-${name}"
+                echo '```'
+                echo ""
+                echo "</details>"
+              } >> "$summary"
+            fi
+          done
+
+          if [ "$changed" -eq 0 ]
+          then
+            echo "" >> "$summary"
+            echo "_No rendered manifest changes across the test-values scenarios._" >> "$summary"
+          fi
+
+          # Always publish the full diff to the job summary.
+          cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+
+          # Cap the PR comment to stay well under GitHub's 65536-char limit.
+          if [ "$(wc -c < "$summary")" -gt 60000 ]
+          then
+            head -c 60000 "$summary" > diff-comment.md
+            {
+              echo ""
+              echo "…diff truncated — see the full render diff in the workflow job summary."
+            } >> diff-comment.md
+          else
+            cp "$summary" diff-comment.md
+          fi
+
+      - name: Post sticky comment
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: helm-render-diff
+          path: diff-comment.md

--- a/.github/workflows/lint-render.yaml
+++ b/.github/workflows/lint-render.yaml
@@ -1,0 +1,70 @@
+name: Lint & Render
+
+# Hard gate: helm lint + helm template + kubeconform schema validation across a
+# representative value set per backend. Runs on GitHub-hosted runners with only
+# public actions (this is a public repo — no self-hosted runners, no secrets).
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  KUBE_VERSION: "1.29.0"
+  KUBECONFORM_VERSION: "v0.6.7"
+
+jobs:
+  lint-render:
+    name: lint-render (${{ matrix.values }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        values:
+          - test-values/filesystem.yaml
+          - test-values/transient.yaml
+          - test-values/s3.yaml
+          - test-values/azureblob.yaml
+          - test-values/gcs.yaml
+          - test-values/b2.yaml
+          - test-values/openstack-swift.yaml
+          - test-values/rackspace.yaml
+          - test-values/multi-backend.yaml
+          - test-values/ingress.yaml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.19.2
+
+      - name: Helm lint
+        run: helm lint charts/s3proxy --values "${{ matrix.values }}"
+
+      - name: Helm template
+        run: |
+          helm template s3proxy charts/s3proxy \
+            --values "${{ matrix.values }}" \
+            --kube-version "${KUBE_VERSION}" > rendered.yaml
+          echo "----- rendered manifests -----"
+          cat rendered.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz kubeconform
+          sudo install kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Validate rendered manifests (kubeconform)
+        run: |
+          kubeconform -strict -summary \
+            -kubernetes-version "${KUBE_VERSION}" \
+            -schema-location default \
+            rendered.yaml

--- a/.github/workflows/verify-chart-version.yaml
+++ b/.github/workflows/verify-chart-version.yaml
@@ -5,8 +5,12 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - charts/s3proxy/**
+    # No `paths:` filter on purpose. `verify-version` is a REQUIRED status check
+    # (branch ruleset on main). With a path filter, PRs that don't touch
+    # charts/s3proxy/** would skip this job, the required check would never be
+    # reported, and the PR would be blocked forever ("Expected — waiting for
+    # status"). Instead the job always runs and no-ops (passes) when the chart is
+    # not modified — see the "Detect chart changes" step below.
 
 jobs:
   verify-version:
@@ -22,8 +26,22 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Detect chart changes
+        id: changes
+        run: |
+          # cwd is ./charts/s3proxy (job default), so `-- .` scopes the diff to the chart.
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD -- . | grep -q .
+          then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Chart files changed — running version check."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes under charts/s3proxy/** — version check is a no-op for this PR."
+          fi
+
       - name: Get current chart version
         id: current_version
+        if: steps.changes.outputs.changed == 'true'
         run: |
           CURRENT_VERSION=$(yq '.version' Chart.yaml)
           echo "Current Chart version: $CURRENT_VERSION"
@@ -31,6 +49,7 @@ jobs:
 
       - name: Get latest release version
         id: latest_release
+        if: steps.changes.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -76,13 +95,13 @@ jobs:
           git checkout HEAD -- Chart.yaml
 
       - name: Install semver comparison tool
-        if: steps.latest_release.outputs.has_release == 'true'
+        if: steps.changes.outputs.changed == 'true' && steps.latest_release.outputs.has_release == 'true'
         run: |
           # Install Node.js semver tool for accurate version comparison
           npm install -g semver
 
       - name: Compare versions
-        if: steps.latest_release.outputs.has_release == 'true'
+        if: steps.changes.outputs.changed == 'true' && steps.latest_release.outputs.has_release == 'true'
         run: |
           CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
           RELEASE_VERSION="${{ steps.latest_release.outputs.version }}"
@@ -125,7 +144,12 @@ jobs:
         if: always()
         run: |
           # Write to GitHub workflow summary
-          if [ "${{ steps.latest_release.outputs.has_release }}" != "true" ]
+          if [ "${{ steps.changes.outputs.changed }}" != "true" ]
+          then
+            echo "## 📋 Chart Version Check Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Status:** No changes under \`charts/s3proxy/**\` — version check not required for this PR." >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.latest_release.outputs.has_release }}" != "true" ]
           then
             echo "## 📋 Chart Version Check Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to s3proxy-chart
+
+Thanks for contributing! This chart deploys [S3Proxy](https://github.com/gaul/s3proxy)
+to Kubernetes. Please read the notes below before opening a pull request.
+
+## Chart layout
+
+- The chart lives in [`charts/s3proxy/`](charts/s3proxy).
+- **`README.md` is auto-generated** by helm-docs from
+  [`charts/s3proxy/README.md.gotmpl`](charts/s3proxy/README.md.gotmpl) and
+  `values.yaml` doc comments. Never edit `README.md` directly — edit the template
+  and/or the `values.yaml` comments.
+- Bump `version` in [`charts/s3proxy/Chart.yaml`](charts/s3proxy/Chart.yaml) for any
+  change under `charts/s3proxy/**` — the `verify-chart-version` check enforces that
+  the version is greater than the latest release.
+
+## CI checks
+
+Every PR runs three checks (all on GitHub-hosted runners — no self-hosted runners,
+no secrets, so they are safe to run for fork PRs):
+
+| Workflow | What it does | Gate |
+|----------|--------------|------|
+| **Lint & Render** (`lint-render.yaml`) | `helm lint` + `helm template` + `kubeconform` schema validation across one value set per backend in [`test-values/`](test-values) | Blocking |
+| **Helm Render Diff** (`helm-diff.yaml`) | Renders each `test-values/` scenario on the PR base and head and posts a manifest diff as a sticky PR comment | Informational |
+| **Functional Test (kind)** (`functional-test.yaml`) | Spins up an ephemeral [kind](https://kind.sigs.k8s.io) cluster, deploys mock backends ([MinIO](https://min.io), [Azurite](https://github.com/Azure/Azurite)), installs the chart, and runs a real S3 round-trip through s3proxy | Blocking (azureblob leg non-blocking, see below) |
+
+### Adding coverage for a change
+
+- Touching a template or `values.yaml`? Make sure the affected backend has a
+  representative file in [`test-values/`](test-values); add one if not.
+- Adding functional coverage for a backend needs a lightweight in-cluster mock
+  (see [`ci/functional/mocks/`](ci/functional/mocks)) and a values file in
+  [`ci/functional/values/`](ci/functional/values), then a matrix entry in
+  `functional-test.yaml`.
+
+### Known non-blocking legs
+
+The functional test surfaced pre-existing chart bugs. These legs run with
+`continue-on-error` so they do not block PRs, and each will auto-go-green once its
+bug is fixed — the failing round-trip is the functional test doing its job:
+
+- **filesystem** / **transient** — the chart does not emit
+  `jclouds.identity`/`jclouds.credential` for local backends, so s3proxy refuses
+  to start. Tracked in **DND-1442**.
+- **azureblob** — the chart emits `jclouds.azureblob.endpoint` instead of the
+  provider-agnostic `jclouds.endpoint`, so a custom endpoint (including the Azurite
+  mock) is ignored. Tracked in **DND-1416**.
+
+The **s3 → MinIO** leg is the blocking functional gate.
+
+`autoscaling` is deliberately not enabled in any `test-values/` scenario because
+`hpa.yaml` still emits the removed `autoscaling/v2beta1` API (kubeconform rejects
+it) — tracked in **DND-1443**. Add an autoscaling scenario once that is fixed.
+
+## Fork pull requests
+
+All CI checks are secret-free and run on GitHub-hosted runners, so they are safe
+to approve for external contributions. GitHub requires a maintainer to approve
+workflow runs for first-time / outside contributors — approving them is safe here
+because none of these workflows hold credentials or touch Comet infrastructure.
+
+## Local validation
+
+```bash
+# Lint + render + schema-validate a scenario
+helm lint charts/s3proxy -f test-values/s3.yaml
+helm template s3proxy charts/s3proxy -f test-values/s3.yaml --kube-version 1.29.0 \
+  | kubeconform -strict -summary -kubernetes-version 1.29.0 -schema-location default -
+
+# Functional round-trip against a local kind cluster
+kind create cluster
+kubectl create namespace s3proxy-test
+kubectl apply -n s3proxy-test -f ci/functional/mocks/minio.yaml
+kubectl -n s3proxy-test rollout status deploy --timeout=180s
+helm upgrade --install s3proxy charts/s3proxy -n s3proxy-test \
+  -f ci/functional/values/s3.yaml --wait --timeout 5m
+ci/functional/smoke-test.sh s3proxy s3proxy-test 9000 test-access-key test-secret-key
+kind delete cluster
+```

--- a/ci/functional/mocks/azurite.yaml
+++ b/ci/functional/mocks/azurite.yaml
@@ -1,0 +1,51 @@
+# Azurite — Azure Blob Storage emulator (official Microsoft image) for the
+# s3proxy functional test. Uses Azurite's well-known devstoreaccount1 account,
+# which matches ci/functional/values/azureblob.yaml.
+# Ephemeral — the whole kind cluster is discarded after the test.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azurite
+  labels:
+    app: azurite
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: azurite
+  template:
+    metadata:
+      labels:
+        app: azurite
+    spec:
+      containers:
+        - name: azurite
+          image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+          args:
+            - azurite-blob
+            - --blobHost
+            - 0.0.0.0
+            - --blobPort
+            - "10000"
+          ports:
+            - name: blob
+              containerPort: 10000
+          readinessProbe:
+            tcpSocket:
+              port: 10000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: azurite
+  labels:
+    app: azurite
+spec:
+  selector:
+    app: azurite
+  ports:
+    - name: blob
+      port: 10000
+      targetPort: 10000

--- a/ci/functional/mocks/minio.yaml
+++ b/ci/functional/mocks/minio.yaml
@@ -1,0 +1,61 @@
+# MinIO — S3-compatible mock backend for the s3proxy functional test.
+# Static root credentials (minioadmin/minioadmin) match ci/functional/values/s3.yaml.
+# Ephemeral (emptyDir) — the whole kind cluster is discarded after the test.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-03-12T18-04-18Z
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
+          ports:
+            - name: s3
+              containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000

--- a/ci/functional/smoke-test.sh
+++ b/ci/functional/smoke-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Smoke-test an installed s3proxy release by performing a full S3 round-trip
+# THROUGH the s3proxy Service: create bucket -> put -> get -> compare -> list ->
+# delete. Uses the AWS CLI over a kubectl port-forward, authenticating with the
+# s3proxy client credentials (config.auth.identity / config.auth.secret).
+#
+# Usage: smoke-test.sh RELEASE NAMESPACE PORT IDENTITY SECRET
+#
+# Exit non-zero on any failure (a broken backend wiring makes the round-trip fail).
+set -euo pipefail
+
+RELEASE="${1:?release name required}"
+NAMESPACE="${2:?namespace required}"
+PORT="${3:-9000}"
+IDENTITY="${4:?s3proxy client identity required}"
+SECRET="${5:?s3proxy client secret required}"
+
+LOCAL_PORT=9900
+BUCKET="smoke-$(date +%s)"
+ENDPOINT="http://127.0.0.1:${LOCAL_PORT}"
+SRC="$(mktemp)"
+DL="$(mktemp)"
+
+export AWS_ACCESS_KEY_ID="$IDENTITY"
+export AWS_SECRET_ACCESS_KEY="$SECRET"
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_EC2_METADATA_DISABLED=true
+# AWS CLI v2.23+ adds default data-integrity checksums (CRC headers on PUT and
+# x-amz-checksum-mode on GET) that S3Proxy / jclouds S3-compatible backends do
+# not implement ("NotImplemented"). Only send/validate them when required.
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+export AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
+# s3proxy is not virtual-host aware over an IP endpoint — force path-style.
+aws configure set default.s3.addressing_style path
+
+PF_PID=""
+cleanup() {
+  if [ -n "$PF_PID" ]
+  then
+    kill "$PF_PID" 2>/dev/null || true
+  fi
+  rm -f "$SRC" "$DL"
+}
+trap cleanup EXIT
+
+echo "==> Waiting for deploy/${RELEASE} to be ready"
+kubectl -n "$NAMESPACE" rollout status "deploy/${RELEASE}" --timeout=120s
+
+echo "==> Port-forwarding svc/${RELEASE} ${LOCAL_PORT}:${PORT}"
+kubectl -n "$NAMESPACE" port-forward "svc/${RELEASE}" "${LOCAL_PORT}:${PORT}" >/tmp/s3proxy-pf.log 2>&1 &
+PF_PID=$!
+
+echo "==> Waiting for the port-forward to accept connections"
+ready=false
+for _ in $(seq 1 30)
+do
+  if curl -s -o /dev/null "$ENDPOINT"
+  then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$ready" != "true" ]
+then
+  echo "ERROR: s3proxy did not become reachable on ${ENDPOINT}" >&2
+  cat /tmp/s3proxy-pf.log >&2 || true
+  exit 1
+fi
+
+AWS=(aws --endpoint-url "$ENDPOINT")
+
+echo "==> Creating bucket: $BUCKET"
+"${AWS[@]}" s3api create-bucket --bucket "$BUCKET"
+
+echo "==> Uploading object"
+echo "hello-s3proxy round-trip $(date +%s)" > "$SRC"
+"${AWS[@]}" s3 cp "$SRC" "s3://${BUCKET}/smoke.txt"
+
+echo "==> Downloading object"
+"${AWS[@]}" s3 cp "s3://${BUCKET}/smoke.txt" "$DL"
+
+echo "==> Verifying round-trip integrity"
+cmp "$SRC" "$DL"
+
+echo "==> Listing bucket"
+"${AWS[@]}" s3 ls "s3://${BUCKET}/"
+
+echo "==> Cleaning up"
+"${AWS[@]}" s3 rm "s3://${BUCKET}/smoke.txt"
+"${AWS[@]}" s3api delete-bucket --bucket "$BUCKET" || true
+
+echo "✅ Smoke test passed for release '${RELEASE}'"

--- a/ci/functional/values/azureblob.yaml
+++ b/ci/functional/values/azureblob.yaml
@@ -1,0 +1,29 @@
+# Functional-test values: Azure Blob backend pointed at the in-cluster Azurite
+# mock (ci/functional/mocks/azurite.yaml -> Service "azurite:10000") using
+# Azurite's well-known devstoreaccount1 credentials.
+#
+# NOTE: expected to FAIL against current main until DND-1416 is fixed — the chart
+# emits jclouds.azureblob.endpoint (typo) instead of jclouds.endpoint, so the
+# custom Azurite endpoint is ignored. This leg runs non-blocking in CI and is a
+# live demonstration that the functional test catches the regression.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    azureblob:
+      enabled: true
+      provider: azureblob
+      account: devstoreaccount1
+      endpoint: http://azurite:10000/devstoreaccount1
+      key:
+        value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+persistence:
+  enabled: false
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/ci/functional/values/filesystem.yaml
+++ b/ci/functional/values/filesystem.yaml
@@ -1,0 +1,18 @@
+# Functional-test values: filesystem backend (self-contained, no mock needed).
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: true
+      nio2: true
+      basedir: /data/s3proxy
+persistence:
+  enabled: true
+  size: 1Gi
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/ci/functional/values/s3.yaml
+++ b/ci/functional/values/s3.yaml
@@ -1,0 +1,25 @@
+# Functional-test values: S3 backend pointed at the in-cluster MinIO mock
+# (ci/functional/mocks/minio.yaml -> Service "minio:9000").
+# Uses the generic S3 provider (aws: false) with a custom endpoint.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    s3:
+      enabled: true
+      aws: false
+      region: us-east-1
+      endpoint: http://minio:9000
+      accessKeyID: minioadmin
+      secretAccessKey:
+        value: minioadmin
+persistence:
+  enabled: false
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/ci/functional/values/transient.yaml
+++ b/ci/functional/values/transient.yaml
@@ -1,0 +1,18 @@
+# Functional-test values: transient (in-memory) backend, no persistence/mock.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    transient:
+      enabled: true
+      nio2: true
+persistence:
+  enabled: false
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/test-values/azureblob.yaml
+++ b/test-values/azureblob.yaml
@@ -1,0 +1,20 @@
+# Render/lint scenario: Azure Blob backend with account + key, endpoint unset.
+# Exercises the computed-default-endpoint code path (see DND-1416: the endpoint
+# line is currently guarded so the default is unreachable — a per-backend render
+# test makes that regression visible in the diff).
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    azureblob:
+      enabled: true
+      provider: azureblob
+      account: teststorageaccount
+      key:
+        value: dGVzdC1henVyZS1hY2NvdW50LWtleQ==
+persistence:
+  enabled: false

--- a/test-values/b2.yaml
+++ b/test-values/b2.yaml
@@ -1,0 +1,16 @@
+# Render/lint scenario: Backblaze B2 backend.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    b2:
+      enabled: true
+      account: b2-account-id
+      applicationKey:
+        value: b2-application-key
+persistence:
+  enabled: false

--- a/test-values/filesystem.yaml
+++ b/test-values/filesystem.yaml
@@ -1,0 +1,15 @@
+# Render/lint scenario: filesystem backend (default) with a PVC.
+config:
+  logLevel: INFO
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: true
+      nio2: true
+      basedir: /data/s3proxy
+persistence:
+  enabled: true
+  size: 1Gi

--- a/test-values/gcs.yaml
+++ b/test-values/gcs.yaml
@@ -1,0 +1,21 @@
+# Render/lint scenario: Google Cloud Storage backend using an existing secret
+# for the private key. Exercises the gcs-private-key volume + volumeMount +
+# `jclouds.credential=/credentials/gcs-private.key` render path in
+# deployment.yaml and configmap.yaml.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    googleCloudStorage:
+      enabled: true
+      projectID: test-project
+      clientEmail: s3proxy@test-project.iam.gserviceaccount.com
+      privateKey:
+        existingSecret: gcs-private-key
+        secretKey: private.key
+persistence:
+  enabled: false

--- a/test-values/ingress.yaml
+++ b/test-values/ingress.yaml
@@ -1,0 +1,55 @@
+# Render/lint scenario: exposure + extras on top of the filesystem backend.
+# Exercises ingress (className/hosts/tls), CORS, podLabels/podAnnotations merge,
+# extraEnvVars, resources, and a created ServiceAccount.
+# NOTE: autoscaling is intentionally NOT enabled here — hpa.yaml still emits the
+# removed autoscaling/v2beta1 API, which kubeconform (strict, modern K8s) rejects
+# (tracked in DND-1443). Add an autoscaling scenario once that is fixed.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  cors:
+    enabled: true
+    allowOrigins:
+      - https://app.example.com
+    allowCredential: true
+  backends:
+    filesystem:
+      enabled: true
+      nio2: true
+      basedir: /data/s3proxy
+serviceAccount:
+  create: true
+podLabels:
+  team: storage
+  cost-center: "1234"
+podAnnotations:
+  prometheus.io/scrape: "true"
+extraEnvVars:
+  - name: JAVA_OPTS
+    value: "-Xmx1g -Xms256m"
+resources:
+  limits:
+    cpu: "1"
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  hosts:
+    - host: s3.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: s3proxy-tls
+      hosts:
+        - s3.example.com
+persistence:
+  enabled: true
+  size: 1Gi

--- a/test-values/multi-backend.yaml
+++ b/test-values/multi-backend.yaml
@@ -1,0 +1,28 @@
+# Render/lint scenario: two backends enabled at once (S3 + Azure Blob).
+# Exercises the if/else-if credential branching in secret.yaml (only the first
+# enabled backend's credentials are emitted) and multiple backend .properties
+# keys + multiple --properties args in the deployment.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    s3:
+      enabled: true
+      aws: false
+      region: us-east-1
+      endpoint: http://minio.example:9000
+      accessKeyID: minio-access-key
+      secretAccessKey:
+        value: minio-secret-key
+    azureblob:
+      enabled: true
+      provider: azureblob
+      account: teststorageaccount
+      key:
+        value: dGVzdC1henVyZS1hY2NvdW50LWtleQ==
+persistence:
+  enabled: false

--- a/test-values/openstack-swift.yaml
+++ b/test-values/openstack-swift.yaml
@@ -1,0 +1,20 @@
+# Render/lint scenario: OpenStack Swift backend.
+# Exercises the "tenant:user" composite jclouds.identity render.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    openstackSwift:
+      enabled: true
+      authURL: https://auth.example.com/v3
+      tenantName: test-tenant
+      userName: test-user
+      password:
+        value: test-password
+      region: RegionOne
+persistence:
+  enabled: false

--- a/test-values/rackspace.yaml
+++ b/test-values/rackspace.yaml
@@ -1,0 +1,17 @@
+# Render/lint scenario: Rackspace Cloud Files backend (US region).
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    rackspaceCloudfiles:
+      enabled: true
+      region: us
+      userName: test-user
+      apiKey:
+        value: test-api-key
+persistence:
+  enabled: false

--- a/test-values/s3.yaml
+++ b/test-values/s3.yaml
@@ -1,0 +1,21 @@
+# Render/lint scenario: S3 backend (aws-s3 provider) with a custom endpoint.
+# Exercises the jclouds.region / jclouds.endpoint / jclouds.identity render path
+# and the S3 credential branch in secret.yaml.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    s3:
+      enabled: true
+      aws: true
+      region: us-east-1
+      endpoint: https://s3.us-east-1.amazonaws.com
+      accessKeyID: AKIAIOSFODNN7EXAMPLE
+      secretAccessKey:
+        value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+persistence:
+  enabled: false

--- a/test-values/transient.yaml
+++ b/test-values/transient.yaml
@@ -1,0 +1,14 @@
+# Render/lint scenario: transient (in-memory) backend, no persistence.
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: false
+    transient:
+      enabled: true
+      nio2: true
+persistence:
+  enabled: false


### PR DESCRIPTION
## What and why

s3proxy-chart had no chart testing. It only ran `verify-chart-version`, `release`, and `preview-readme`, so template and config regressions were caught only by manual review (for example the azureblob bugs in DND-1416). This PR adds lint, render-diff, and functional testing, and fixes the required version check so it no longer blocks non-chart PRs. Resolves DND-1417.

Everything runs on GitHub-hosted runners with public, SHA-pinned actions. This is a public repo, so it deliberately avoids self-hosted runners and the private `gha-tools` action: fork PRs cannot pull a private action, and self-hosted runners must not run fork code.

## Workflows added

| Workflow | What it does | Gate |
|----------|--------------|------|
| `lint-render.yaml` | `helm lint` + `helm template` + `kubeconform` (strict) across one value set per backend in `test-values/` | Blocking |
| `helm-diff.yaml` | Renders every `test-values/` scenario on base vs head, then posts a summary table plus per-scenario diffs as a PR comment. Falls back to a table-only comment that links to the job summary when the full diff is too large. | Informational |
| `functional-test.yaml` | Spins up an ephemeral [kind](https://kind.sigs.k8s.io) cluster, deploys mock backends ([MinIO](https://min.io), [Azurite](https://github.com/Azure/Azurite)), installs the chart, and runs a real S3 round-trip | Blocking (s3 only, see below) |

The `helm-diff` output mirrors the format used by the self-hosted chart (`comet-ml/gha-tools` helm-diff): a summary table with per-scenario `+adds/-dels` counts and status, followed by collapsible per-scenario diffs. It posts via first-party `actions/github-script` and minimizes prior diff comments as outdated, matching this repo's `preview-readme.yaml` convention.

## Workflow fixed

`verify-chart-version.yaml`: `verify-version` is a required status check (branch ruleset on `main`). Its `paths: charts/s3proxy/**` filter meant PRs that did not touch the chart skipped the job, so the required check was never reported and the PR stayed blocked. The filter is removed and the real steps are gated on a git-diff change detector, so the check now always runs. It passes as a no-op when `charts/s3proxy/**` is not modified, and runs the original semver bump check when it is.

## Functional backend coverage

- **s3 to MinIO**: hard gate (create, put, get, verify, list, delete through s3proxy).
- **filesystem, transient, azureblob**: non-blocking (`soft_fail`) because they fail on current `main` due to pre-existing chart bugs (below). Each turns green automatically once its bug is fixed.
- **gcs, b2, openstack-swift, rackspace**: render-only (covered by `lint-render` and `helm-diff`). gcs has no `jclouds.endpoint` override in the chart, and the others have no lightweight in-cluster emulator.

## Pre-existing chart bugs this CI surfaced

- **DND-1442**: `filesystem` and `transient` omit `jclouds.identity` / `jclouds.credential`, so s3proxy crash-loops on startup and the chart is undeployable with its default filesystem backend.
- **DND-1443**: `hpa.yaml` emits the removed `autoscaling/v2beta1` API (gone in Kubernetes 1.25), so kubeconform rejects it. Autoscaling is excluded from the gated value sets until this is fixed.
- **DND-1416**: azureblob emits `jclouds.azureblob.endpoint` instead of `jclouds.endpoint`, so a custom endpoint is ignored. The functional round-trip returns 403 because s3proxy falls back to real Azure.

## Verification (local)

- `helm lint` and `helm template`: all value sets pass.
- `kubeconform` strict (k8s 1.29): all render sets valid, and it correctly rejects the `v2beta1` HPA.
- `actionlint` on the new workflows and `shellcheck` on `smoke-test.sh`: clean.
- kind end to end: s3 to MinIO round-trip passes; filesystem, transient, and azureblob fail as expected per the bugs above.

## Fork PRs

All checks are secret-free and safe to approve and run for fork PRs. See `CONTRIBUTING.md`.
