### PR TITLE
[DND-1417] Add multi-backend functional test leg (s3 + azureblob + filesystem, non-blocking)

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -16,6 +16,16 @@ name: Functional Test (kind)
 #                              fixes the endpoint property (jclouds.azureblob.endpoint
 #                              -> jclouds.endpoint); the failing round-trip is the
 #                              functional test demonstrably catching that regression.
+#   multi-backend           -> s3 (MinIO) + azureblob (Azurite) + filesystem (PVC)
+#                              in ONE release, round-tripping one bucket per backend
+#                              (smoke-s3-*/smoke-az-*/smoke-fs-*). NON-BLOCKING:
+#                              cannot pass on current main — blocked by DND-1442 and
+#                              DND-1416, plus two multi-backend chart gaps (secret.yaml
+#                              emits only the first enabled backend's jclouds.credential
+#                              into the shared secret.properties, and there is no
+#                              per-backend bucket-locator to route buckets between
+#                              backends on the shared endpoint). See the notes in
+#                              ci/functional/values/multi-backend.yaml.
 # Each soft_fail leg auto-goes-green once its bug is fixed.
 # gcs/b2/openstack-swift/rackspace are render-only (covered by lint-render + helm-diff):
 # gcs has no jclouds.endpoint override in the chart, and the others have no
@@ -57,6 +67,11 @@ jobs:
             values: ci/functional/values/azureblob.yaml
             mock: ci/functional/mocks/azurite.yaml
             soft_fail: true
+          - backend: multi-backend
+            values: ci/functional/values/multi-backend.yaml
+            mock: ci/functional/mocks/minio.yaml ci/functional/mocks/azurite.yaml
+            buckets: smoke-s3 smoke-az smoke-fs
+            soft_fail: true
     env:
       NAMESPACE: s3proxy-test
       RELEASE: s3proxy
@@ -75,11 +90,16 @@ jobs:
       - name: Create namespace
         run: kubectl create namespace "${NAMESPACE}"
 
-      - name: Deploy mock backend (${{ matrix.backend }})
+      - name: Deploy mock backends (${{ matrix.backend }})
         if: matrix.mock
+        # matrix.mock is a space-separated list of manifests (multi-backend
+        # scenarios deploy several mocks).
         run: |
-          kubectl apply -n "${NAMESPACE}" -f "${{ matrix.mock }}"
-          kubectl -n "${NAMESPACE}" rollout status deploy --timeout=180s
+          for mock in ${{ matrix.mock }}
+          do
+            kubectl apply -n "${NAMESPACE}" -f "${mock}"
+          done
+          kubectl -n "${NAMESPACE}" wait --for=condition=Available deploy --all --timeout=180s
 
       - name: Install s3proxy
         run: |
@@ -89,9 +109,14 @@ jobs:
             --wait --timeout 5m
 
       - name: Smoke test (S3 round-trip)
+        # matrix.buckets is a space-separated list of bucket prefixes — one
+        # round-trip per prefix (multi-backend scenarios use one per backend).
         run: |
           chmod +x ci/functional/smoke-test.sh
-          ci/functional/smoke-test.sh "${RELEASE}" "${NAMESPACE}" 9000 test-access-key test-secret-key
+          for prefix in ${{ matrix.buckets || 'smoke' }}
+          do
+            ci/functional/smoke-test.sh "${RELEASE}" "${NAMESPACE}" 9000 test-access-key test-secret-key "${prefix}"
+          done
 
       - name: Diagnostics on failure
         if: failure()

--- a/ci/functional/smoke-test.sh
+++ b/ci/functional/smoke-test.sh
@@ -4,7 +4,11 @@
 # delete. Uses the AWS CLI over a kubectl port-forward, authenticating with the
 # s3proxy client credentials (config.auth.identity / config.auth.secret).
 #
-# Usage: smoke-test.sh RELEASE NAMESPACE PORT IDENTITY SECRET
+# Usage: smoke-test.sh RELEASE NAMESPACE PORT IDENTITY SECRET [BUCKET_PREFIX]
+#
+# BUCKET_PREFIX (default "smoke") names the test bucket; multi-backend scenarios
+# call this script once per backend with a distinct prefix so each round-trip
+# targets a bucket routed to that backend.
 #
 # Exit non-zero on any failure (a broken backend wiring makes the round-trip fail).
 set -euo pipefail
@@ -14,9 +18,10 @@ NAMESPACE="${2:?namespace required}"
 PORT="${3:-9000}"
 IDENTITY="${4:?s3proxy client identity required}"
 SECRET="${5:?s3proxy client secret required}"
+BUCKET_PREFIX="${6:-smoke}"
 
 LOCAL_PORT=9900
-BUCKET="smoke-$(date +%s)"
+BUCKET="${BUCKET_PREFIX}-$(date +%s)"
 ENDPOINT="http://127.0.0.1:${LOCAL_PORT}"
 SRC="$(mktemp)"
 DL="$(mktemp)"
@@ -90,4 +95,4 @@ echo "==> Cleaning up"
 "${AWS[@]}" s3 rm "s3://${BUCKET}/smoke.txt"
 "${AWS[@]}" s3api delete-bucket --bucket "$BUCKET" || true
 
-echo "✅ Smoke test passed for release '${RELEASE}'"
+echo "✅ Smoke test passed for release '${RELEASE}' (bucket ${BUCKET})"

--- a/ci/functional/values/multi-backend.yaml
+++ b/ci/functional/values/multi-backend.yaml
@@ -1,0 +1,52 @@
+# Functional-test values: THREE backends enabled in one release — s3 (MinIO
+# mock), azureblob (Azurite mock) and filesystem (PVC) — to exercise the chart's
+# multi-backend wiring end-to-end. The workflow round-trips one bucket per
+# backend (smoke-s3-*/smoke-az-*/smoke-fs-*).
+#
+# NOTE: expected to FAIL against current main — runs NON-BLOCKING (soft_fail)
+# until the chart can actually serve multiple backends:
+#   * DND-1442: filesystem emits no jclouds.identity/jclouds.credential, so
+#     s3proxy refuses to start at all.
+#   * DND-1416: azureblob emits jclouds.azureblob.endpoint instead of
+#     jclouds.endpoint, so the Azurite mock endpoint is ignored.
+#   * secret.yaml's if/else-if emits only the FIRST enabled backend's
+#     jclouds.credential (s3 here), and the merge initContainer appends that
+#     same secret.properties to EVERY backend's properties file — azureblob
+#     ends up with MinIO's credential.
+#   * All backend properties files share one s3proxy.endpoint, and the chart
+#     renders the same (global) bucket-locator list into each of them, so there
+#     is no way to route a bucket to a specific backend yet. Needs per-backend
+#     s3proxy.bucket-locator support (e.g. config.backends.<name>.bucketLocators
+#     emitting s3proxy.bucket-locator.N per properties file).
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: true
+      nio2: true
+      basedir: /data/s3proxy
+    s3:
+      enabled: true
+      aws: false
+      region: us-east-1
+      endpoint: http://minio:9000
+      accessKeyID: minioadmin
+      secretAccessKey:
+        value: minioadmin
+    azureblob:
+      enabled: true
+      provider: azureblob
+      account: devstoreaccount1
+      endpoint: http://azurite:10000/devstoreaccount1
+      key:
+        value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+persistence:
+  enabled: true
+  size: 1Gi
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi


### PR DESCRIPTION
## What

Adds a `multi-backend` scenario to the kind functional test: **one release with s3 (MinIO), azureblob (Azurite) and filesystem (PVC) enabled together**, round-tripping one bucket per backend (`smoke-s3-*` / `smoke-az-*` / `smoke-fs-*`).

Multi-backend was previously covered at render level only (`test-values/multi-backend.yaml` through lint-render); nothing installed the chart with several backends and exercised them at runtime.

- `ci/functional/values/multi-backend.yaml` — new scenario values (three backends, aws-v4 client auth).
- `ci/functional/smoke-test.sh` — optional `BUCKET_PREFIX` arg (default `smoke`; existing callers unchanged).
- `.github/workflows/functional-test.yaml` — new matrix leg; the mock-deploy step now takes a space-separated manifest list; the smoke step loops over `matrix.buckets` prefixes (defaults to a single `smoke` run for the existing legs).

## Expected to fail (runs `soft_fail`)

This leg **cannot pass on current `main`** — landing it now pins down the target behavior; making it green is follow-up work:

1. **DND-1442** — filesystem emits no `jclouds.identity`/`jclouds.credential`, so s3proxy refuses to start.
2. **DND-1416** — azureblob emits `jclouds.azureblob.endpoint` instead of `jclouds.endpoint`, so the Azurite mock endpoint is ignored.
3. `secret.yaml`'s `if`/`else if` emits only the **first** enabled backend's `jclouds.credential` into `secret.properties`, and the merge initContainer appends that same file to **every** backend's properties — azureblob ends up with MinIO's credential.
4. All backend properties files share one `s3proxy.endpoint`, and the chart renders the same global bucket-locator list into each, so buckets cannot be routed to a specific backend. Needs per-backend `s3proxy.bucket-locator` support (e.g. `config.backends.<name>.bucketLocators`).

Items 1–2 are already tracked; 3–4 need a chart follow-up ticket.

## Verification

- `helm lint` + `helm template` with the new values: all three `backend-*.properties` ConfigMap keys and `--properties` args render.
- `actionlint` (workflow) and `shellcheck` (smoke-test.sh): clean.
- No files under `charts/s3proxy/**` are touched → no chart version bump; `verify-version` no-ops.

Part of DND-1417 (CI hardening). Follow-up to #19.