### PR TITLE
[DND-1442] Fix filesystem/transient backends failing to start (missing jclouds.identity/credential)

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -7,11 +7,10 @@ name: Functional Test (kind)
 #
 # Backend coverage:
 #   s3                      -> MinIO mock, HARD GATE (full S3 round-trip).
-#   filesystem / transient  -> NON-BLOCKING (soft_fail): the chart does not emit
-#                              jclouds.identity/jclouds.credential for local
-#                              backends, so s3proxy refuses to start
-#                              ("Properties file must contain: jclouds.identity
-#                              and jclouds.credential"). Tracked in DND-1442.
+#   filesystem / transient  -> HARD GATE (install + round-trip). The chart now
+#                              emits placeholder jclouds.identity/jclouds.credential
+#                              for local backends (DND-1442), so s3proxy starts and
+#                              serves. These legs guard that fix against regression.
 #   azureblob               -> Azurite mock, NON-BLOCKING (soft_fail) until DND-1416
 #                              fixes the endpoint property (jclouds.azureblob.endpoint
 #                              -> jclouds.endpoint); the failing round-trip is the
@@ -59,10 +58,8 @@ jobs:
             mock: ci/functional/mocks/minio.yaml
           - backend: filesystem
             values: ci/functional/values/filesystem.yaml
-            soft_fail: true
           - backend: transient
             values: ci/functional/values/transient.yaml
-            soft_fail: true
           - backend: azureblob
             values: ci/functional/values/azureblob.yaml
             mock: ci/functional/mocks/azurite.yaml

--- a/charts/s3proxy/templates/configmap.yaml
+++ b/charts/s3proxy/templates/configmap.yaml
@@ -79,6 +79,10 @@ data:
     jclouds.provider=filesystem
   {{- end }}
     jclouds.filesystem.basedir={{ .Values.config.backends.filesystem.basedir }}
+    # S3Proxy requires jclouds.identity and jclouds.credential in every backend
+    # properties file, even for local backends where the values are unused.
+    jclouds.identity={{ .Values.config.backends.filesystem.identity | default "local" }}
+    jclouds.credential={{ .Values.config.backends.filesystem.credential | default "local" }}
 {{- end }}
 
 {{- if .Values.config.backends.transient.enabled }}
@@ -91,6 +95,10 @@ data:
   {{- else }}
     jclouds.provider=transient
   {{- end }}
+    # S3Proxy requires jclouds.identity and jclouds.credential in every backend
+    # properties file, even for local backends where the values are unused.
+    jclouds.identity={{ .Values.config.backends.transient.identity | default "local" }}
+    jclouds.credential={{ .Values.config.backends.transient.credential | default "local" }}
 {{- end }}
 
 {{- if .Values.config.backends.s3.enabled }}

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -168,12 +168,20 @@ config:
       nio2: true
       # -- Base directory for filesystem backend
       basedir: "/data/s3proxy"
+      # -- jclouds identity. S3Proxy requires jclouds.identity in every backend properties file; the filesystem backend ignores the value, so the "local" placeholder is fine. An empty value falls back to "local".
+      identity: "local"
+      # -- jclouds credential. S3Proxy requires jclouds.credential in every backend properties file; the filesystem backend ignores the value. An empty value falls back to "local".
+      credential: "local"
 
     transient:
       # -- Enable transient (in-memory) backend
       enabled: false
       # -- Use NIO2 implementation (transient-nio2) instead of standard transient
       nio2: true
+      # -- jclouds identity. S3Proxy requires jclouds.identity in every backend properties file; the transient backend ignores the value, so the "local" placeholder is fine. An empty value falls back to "local".
+      identity: "local"
+      # -- jclouds credential. S3Proxy requires jclouds.credential in every backend properties file; the transient backend ignores the value. An empty value falls back to "local".
+      credential: "local"
 
     s3:
       # -- Enable S3 backend


### PR DESCRIPTION
## Problem

S3Proxy requires `jclouds.identity` **and** `jclouds.credential` in *every* backend properties file, even for local backends where the values are unused. The chart emitted neither for `filesystem`/`transient` (only cloud backends set them, via `configmap.yaml` + the `secret.yaml` `if/else if` chain). So a filesystem- or transient-only release crash-loops at startup:

```
[s3proxy] E ... org.gaul.s3proxy.Main:328 |::] Properties file must contain: jclouds.identity and jclouds.credential
```

## Fix

Emit both keys for the local backends in `configmap.yaml`, defaulting to a `local` placeholder via `| default "local"`:

```gotemplate
jclouds.identity={{ .Values.config.backends.filesystem.identity | default "local" }}
jclouds.credential={{ .Values.config.backends.filesystem.credential | default "local" }}
```

For local backends the credential is a fixed dummy, not a secret, so it lives in the ConfigMap rather than the Secret. This keeps the fix self-contained and avoids entangling `secret.yaml`'s `if/else if` credential chain. The `| default "local"` guard means even an explicit empty override (`identity: ""`) still renders a valid value, so this bug can't recur.

### Changes
- `charts/s3proxy/templates/configmap.yaml` — emit `jclouds.identity`/`jclouds.credential` for filesystem + transient.
- `charts/s3proxy/values.yaml` — new `identity`/`credential` keys (default `"local"`) under `config.backends.filesystem` and `config.backends.transient`, with helm-docs `# --` docs (README auto-regenerates on release).
- `.github/workflows/functional-test.yaml` — flip the `filesystem` and `transient` functional legs from `soft_fail` to **hard gates** (they now install + round-trip), guarding the fix against regression. `azureblob` stays `soft_fail` (DND-1416).
