### PR TITLE
Route buckets per backend + make the multi-backend functional test real

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -5,27 +5,20 @@ name: Functional Test (kind)
 # s3proxy. Public repo → GitHub-hosted runner + kind, no cluster credentials, so
 # it is safe to run on every PR (including forks).
 #
-# Backend coverage:
-#   s3                      -> MinIO mock, HARD GATE (full S3 round-trip).
-#   filesystem / transient  -> HARD GATE (install + round-trip). The chart now
-#                              emits placeholder jclouds.identity/jclouds.credential
-#                              for local backends (DND-1442), so s3proxy starts and
-#                              serves. These legs guard that fix against regression.
-#   azureblob               -> Azurite mock, NON-BLOCKING (soft_fail) until DND-1416
-#                              fixes the endpoint property (jclouds.azureblob.endpoint
-#                              -> jclouds.endpoint); the failing round-trip is the
-#                              functional test demonstrably catching that regression.
+# Backend coverage (all HARD GATES):
+#   s3                      -> MinIO mock, full S3 round-trip.
+#   filesystem / transient  -> install + round-trip. The chart emits placeholder
+#                              jclouds.identity/jclouds.credential for local
+#                              backends, so s3proxy starts and serves.
+#   azureblob               -> Azurite mock, full round-trip through the fixed
+#                              jclouds.endpoint (provider-agnostic).
 #   multi-backend           -> s3 (MinIO) + azureblob (Azurite) + filesystem (PVC)
-#                              in ONE release, round-tripping one bucket per backend
-#                              (smoke-s3-*/smoke-az-*/smoke-fs-*). NON-BLOCKING:
-#                              cannot pass on current main — blocked by DND-1442 and
-#                              DND-1416, plus two multi-backend chart gaps (secret.yaml
-#                              emits only the first enabled backend's jclouds.credential
-#                              into the shared secret.properties, and there is no
-#                              per-backend bucket-locator to route buckets between
-#                              backends on the shared endpoint). See the notes in
-#                              ci/functional/values/multi-backend.yaml.
-# Each soft_fail leg auto-goes-green once its bug is fixed.
+#                              in ONE release, with per-backend bucket-locator
+#                              routing. assert-routing.sh writes one bucket per
+#                              backend through s3proxy and verifies each object
+#                              physically lands on its intended backend (MinIO for
+#                              s3, Azurite for azureblob, filesystem by elimination)
+#                              and that no bucket leaks into another backend.
 # gcs/b2/openstack-swift/rackspace are render-only (covered by lint-render + helm-diff):
 # gcs has no jclouds.endpoint override in the chart, and the others have no
 # lightweight in-cluster emulator.
@@ -48,7 +41,6 @@ jobs:
   functional:
     name: functional (${{ matrix.backend }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.soft_fail == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,12 +55,10 @@ jobs:
           - backend: azureblob
             values: ci/functional/values/azureblob.yaml
             mock: ci/functional/mocks/azurite.yaml
-            soft_fail: true
           - backend: multi-backend
             values: ci/functional/values/multi-backend.yaml
             mock: ci/functional/mocks/minio.yaml ci/functional/mocks/azurite.yaml
-            buckets: smoke-s3 smoke-az smoke-fs
-            soft_fail: true
+            verify: routing
     env:
       NAMESPACE: s3proxy-test
       RELEASE: s3proxy
@@ -105,15 +95,19 @@ jobs:
             --values "${{ matrix.values }}" \
             --wait --timeout 5m
 
-      - name: Smoke test (S3 round-trip)
-        # matrix.buckets is a space-separated list of bucket prefixes — one
-        # round-trip per prefix (multi-backend scenarios use one per backend).
+      - name: Verify (${{ matrix.verify || 'round-trip' }})
+        # Single-backend legs: one S3 round-trip through s3proxy.
+        # multi-backend leg (verify=routing): assert each bucket physically lands
+        # on its intended backend (needs aws + az; both are on ubuntu-latest).
         run: |
-          chmod +x ci/functional/smoke-test.sh
-          for prefix in ${{ matrix.buckets || 'smoke' }}
-          do
-            ci/functional/smoke-test.sh "${RELEASE}" "${NAMESPACE}" 9000 test-access-key test-secret-key "${prefix}"
-          done
+          if [ "${{ matrix.verify }}" = "routing" ]
+          then
+            chmod +x ci/functional/assert-routing.sh
+            ci/functional/assert-routing.sh "${RELEASE}" "${NAMESPACE}"
+          else
+            chmod +x ci/functional/smoke-test.sh
+            ci/functional/smoke-test.sh "${RELEASE}" "${NAMESPACE}" 9000 test-access-key test-secret-key
+          fi
 
       - name: Diagnostics on failure
         if: failure()

--- a/charts/s3proxy/README.md.gotmpl
+++ b/charts/s3proxy/README.md.gotmpl
@@ -257,17 +257,27 @@ config:
       another-bucket: "actual-bucket-name"
 ```
 
-### Bucket Locator
+### Bucket Locator (routing buckets to backends)
 
-Assign specific buckets to different backends:
+When more than one backend is enabled, assign buckets to a specific backend with
+that backend's own `bucketLocators` list. S3Proxy reads bucket-locators per
+backend, so each list is emitted only into that backend's properties file. Glob
+patterns are supported. A bucket that matches no backend's list falls through to
+the first-enabled backend (the default).
 
 ```yaml
 config:
-  buckets:
-    locator:
-      - "bucket1"
-      - "bucket2"
-      - "*.test"  # Glob patterns supported
+  backends:
+    s3:
+      enabled: true
+      # ... credentials ...
+      bucketLocators:
+        - "prod-*"
+        - "customer-data"
+    filesystem:
+      enabled: true
+      bucketLocators:
+        - "scratch-*"   # everything else also lands here (first-enabled default)
 ```
 
 ## Monitoring

--- a/charts/s3proxy/templates/configmap.yaml
+++ b/charts/s3proxy/templates/configmap.yaml
@@ -32,12 +32,11 @@ s3proxy.alias.{{ $key }}={{ $value }}
     {{- end }}
   {{- end }}
 
-  {{- if .Values.config.buckets.locator }}
-# Bucket locator
-    {{- range $index, $bucket := .Values.config.buckets.locator }}
-s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
-    {{- end }}
-  {{- end }}
+  {{- /* Bucket locators are per-backend: each backend's properties file lists
+         the buckets it owns (see config.backends.<name>.bucketLocators). They are
+         intentionally NOT emitted here in the shared config, because S3Proxy
+         de-duplicates locators across --properties files (first file wins), so a
+         shared list would route every bucket to only the first backend. */}}
 
   {{- if .Values.config.middlewares.readOnly }}
 # Read-only middleware
@@ -83,6 +82,9 @@ data:
     # properties file, even for local backends where the values are unused.
     jclouds.identity={{ .Values.config.backends.filesystem.identity | default "local" }}
     jclouds.credential={{ .Values.config.backends.filesystem.credential | default "local" }}
+  {{- range $index, $bucket := .Values.config.backends.filesystem.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.config.backends.transient.enabled }}
@@ -99,6 +101,9 @@ data:
     # properties file, even for local backends where the values are unused.
     jclouds.identity={{ .Values.config.backends.transient.identity | default "local" }}
     jclouds.credential={{ .Values.config.backends.transient.credential | default "local" }}
+  {{- range $index, $bucket := .Values.config.backends.transient.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.config.backends.s3.enabled }}
@@ -123,6 +128,9 @@ data:
   {{- if .Values.config.backends.s3.secretAccessKey.value }}
     # Credential will be merged from the secret properties file
   {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.s3.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.config.backends.azureblob.enabled }}
@@ -131,14 +139,17 @@ data:
 
     # Azure Blob backend configuration
     jclouds.provider={{ .Values.config.backends.azureblob.provider }}
-  {{- if .Values.config.backends.azureblob.endpoint }}
-    jclouds.azureblob.endpoint={{ .Values.config.backends.azureblob.endpoint | default (printf "https://%s.blob.core.windows.net" .Values.config.backends.azureblob.account) }}
+  {{- if or .Values.config.backends.azureblob.endpoint .Values.config.backends.azureblob.account }}
+    jclouds.endpoint={{ .Values.config.backends.azureblob.endpoint | default (printf "https://%s.blob.core.windows.net" .Values.config.backends.azureblob.account) }}
   {{- end }}
   {{- if .Values.config.backends.azureblob.account }}
     jclouds.identity={{ .Values.config.backends.azureblob.account }}
   {{- end }}
   {{- if or .Values.config.backends.azureblob.key.value .Values.config.backends.azureblob.sasToken.value }}
     # Credentials will be merged from the secret properties file
+  {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.azureblob.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
   {{- end }}
 {{- end }}
 
@@ -161,6 +172,9 @@ data:
     # Private key credential will be merged from the secret properties file
     # jclouds.credential will be provided by the secret
   {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.googleCloudStorage.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.config.backends.b2.enabled }}
@@ -174,6 +188,9 @@ data:
   {{- end }}
   {{- if .Values.config.backends.b2.applicationKey.value }}
     # Credential will be merged from the secret properties file
+  {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.b2.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
   {{- end }}
 {{- end }}
 
@@ -195,6 +212,9 @@ data:
   {{- if .Values.config.backends.openstackSwift.password.value }}
     # Credential will be merged from the secret properties file
   {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.openstackSwift.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.config.backends.rackspaceCloudfiles.enabled }}
@@ -212,5 +232,8 @@ data:
   {{- end }}
   {{- if .Values.config.backends.rackspaceCloudfiles.apiKey.value }}
     # Credential will be merged from the secret properties file
+  {{- end }}
+  {{- range $index, $bucket := .Values.config.backends.rackspaceCloudfiles.bucketLocators }}
+    s3proxy.bucket-locator.{{ add $index 1 }}={{ $bucket }}
   {{- end }}
 {{- end }}

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -44,15 +44,18 @@ spec:
               set -e
               echo "Merging configuration files..."
 
-              # Check if secret properties file exists
-              SECRET_FILE="/secret/secret.properties"
+              # secret-common.properties holds the client-facing auth and is
+              # appended to every backend file. Each backend additionally gets
+              # its own secret-<backend>.properties (its jclouds.credential), so
+              # one backend's credential never leaks into another's file.
+              COMMON_SECRET="/secret/secret-common.properties"
 
               # Loop through all properties files in the config directory
               for config_file in /config/*.properties
               do
                 if [ -f "$config_file" ]
                 then
-                  # Get the filename
+                  # Get the filename, e.g. backend-s3.properties
                   filename=$(basename "$config_file")
                   output_file="/merged-config/$filename"
 
@@ -61,11 +64,22 @@ spec:
                   # Copy base config file to output
                   cp "$config_file" "$output_file"
 
-                  # If secret file exists, append its contents (overriding duplicates)
-                  if [ -f "$SECRET_FILE" ]
+                  # Append the shared client-auth secret, if present
+                  if [ -f "$COMMON_SECRET" ]
                   then
                     echo "" >> "$output_file"  # Add newline separator
-                    cat "$SECRET_FILE" >> "$output_file"
+                    cat "$COMMON_SECRET" >> "$output_file"
+                  fi
+
+                  # Append this backend's own secret: backend-<name>.properties
+                  # pairs with secret-<name>.properties
+                  backend="${filename#backend-}"
+                  backend="${backend%.properties}"
+                  backend_secret="/secret/secret-${backend}.properties"
+                  if [ -f "$backend_secret" ]
+                  then
+                    echo "" >> "$output_file"  # Add newline separator
+                    cat "$backend_secret" >> "$output_file"
                   fi
                 fi
               done

--- a/charts/s3proxy/templates/secret.yaml
+++ b/charts/s3proxy/templates/secret.yaml
@@ -6,48 +6,53 @@ metadata:
     {{- include "s3proxy.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  # Properties file containing sensitive configuration values
-  # This will be merged with the backend properties files by the init container
-  secret.properties: |
+  # Sensitive properties merged into the backend properties files by the
+  # merge-configs initContainer:
+  #   * secret-common.properties  -> appended to EVERY backend file (client auth).
+  #   * secret-<backend>.properties -> appended ONLY to that backend's file, so
+  #     each backend gets its own jclouds.credential and never another backend's.
+  # Local backends (filesystem/transient) need no secret file; their placeholder
+  # jclouds.identity/credential come from the ConfigMap.
 {{- if and .Values.config.auth.identity .Values.config.auth.secret }}
-    # S3Proxy authentication credentials (for clients connecting to s3proxy)
+  secret-common.properties: |
+    # S3Proxy client authentication credentials (shared by all backends)
     s3proxy.identity={{ .Values.config.auth.identity }}
     s3proxy.credential={{ .Values.config.auth.secret }}
 {{- end }}
-
-{{- if .Values.config.backends.s3.enabled }}
-  {{- if .Values.config.backends.s3.secretAccessKey.value }}
-    # S3 backend credentials
+{{- if and .Values.config.backends.s3.enabled .Values.config.backends.s3.secretAccessKey.value }}
+  secret-s3.properties: |
+    # S3 backend credential
     jclouds.credential={{ .Values.config.backends.s3.secretAccessKey.value }}
-  {{- end }}
-{{- else if .Values.config.backends.azureblob.enabled }}
-  {{- if or .Values.config.backends.azureblob.key.value .Values.config.backends.azureblob.sasToken.value }}
+{{- end }}
+{{- if .Values.config.backends.azureblob.enabled }}
+{{- if or .Values.config.backends.azureblob.key.value .Values.config.backends.azureblob.sasToken.value }}
+  secret-azureblob.properties: |
     # Azure Blob backend credentials
-  {{- end }}
-  {{- if .Values.config.backends.azureblob.key.value }}
+{{- if .Values.config.backends.azureblob.key.value }}
     jclouds.credential={{ .Values.config.backends.azureblob.key.value }}
-  {{- end }}
-  {{- if .Values.config.backends.azureblob.sasToken.value }}
+{{- end }}
+{{- if .Values.config.backends.azureblob.sasToken.value }}
     jclouds.azureblob.sas={{ .Values.config.backends.azureblob.sasToken.value }}
-  {{- end }}
-{{- else if .Values.config.backends.googleCloudStorage.enabled }}
-  {{- if .Values.config.backends.googleCloudStorage.privateKey.value }}
-    # Google Cloud Storage backend credentials (privateKey stored in secret)
-    jclouds.credential=jclouds.credential={{ .Values.config.backends.googleCloudStorage.privateKey.value | trim | replace "\n" "\\n\\" }}
-  {{- end }}
-{{- else if .Values.config.backends.b2.enabled }}
-  {{- if .Values.config.backends.b2.applicationKey.value }}
-    # Backblaze B2 backend credentials
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.config.backends.googleCloudStorage.enabled .Values.config.backends.googleCloudStorage.privateKey.value }}
+  secret-google-cloud-storage.properties: |
+    # Google Cloud Storage backend credential (PEM private key)
+    jclouds.credential={{ .Values.config.backends.googleCloudStorage.privateKey.value | trim | replace "\n" "\\n\\" }}
+{{- end }}
+{{- if and .Values.config.backends.b2.enabled .Values.config.backends.b2.applicationKey.value }}
+  secret-b2.properties: |
+    # Backblaze B2 backend credential
     jclouds.credential={{ .Values.config.backends.b2.applicationKey.value }}
-  {{- end }}
-{{- else if .Values.config.backends.openstackSwift.enabled }}
-  {{- if .Values.config.backends.openstackSwift.password.value }}
-    # OpenStack Swift backend credentials
+{{- end }}
+{{- if and .Values.config.backends.openstackSwift.enabled .Values.config.backends.openstackSwift.password.value }}
+  secret-openstack-swift.properties: |
+    # OpenStack Swift backend credential
     jclouds.credential={{ .Values.config.backends.openstackSwift.password.value }}
-  {{- end }}
-{{- else if .Values.config.backends.rackspaceCloudfiles.enabled }}
-  {{- if .Values.config.backends.rackspaceCloudfiles.apiKey.value }}
-    # Rackspace Cloud Files backend credentials
+{{- end }}
+{{- if and .Values.config.backends.rackspaceCloudfiles.enabled .Values.config.backends.rackspaceCloudfiles.apiKey.value }}
+  secret-rackspace-cloudfiles.properties: |
+    # Rackspace Cloud Files backend credential
     jclouds.credential={{ .Values.config.backends.rackspaceCloudfiles.apiKey.value }}
-  {{- end }}
 {{- end }}

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -144,11 +144,10 @@ config:
     alias: {}
       # example-bucket: "real-bucket-name"
 
-    # -- Assign specific buckets to different backends (glob patterns supported)
-    locator: []
-      # - "bucket1"
-      # - "bucket2"
-      # - "*.test"  # glob pattern supported
+    # Bucket-to-backend routing is configured PER BACKEND via
+    # config.backends.<name>.bucketLocators. S3Proxy reads bucket-locators from
+    # each backend's own properties file, so a single global list would route
+    # every bucket to only the first backend.
 
   middlewares:
     # -- Make backend read-only
@@ -172,6 +171,8 @@ config:
       identity: "local"
       # -- jclouds credential. S3Proxy requires jclouds.credential in every backend properties file; the filesystem backend ignores the value. An empty value falls back to "local".
       credential: "local"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     transient:
       # -- Enable transient (in-memory) backend
@@ -182,6 +183,8 @@ config:
       identity: "local"
       # -- jclouds credential. S3Proxy requires jclouds.credential in every backend properties file; the transient backend ignores the value. An empty value falls back to "local".
       credential: "local"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     s3:
       # -- Enable S3 backend
@@ -202,6 +205,8 @@ config:
         existingSecret: ""
         # -- Key in the existing secret containing the secret access key
         secretKey: "secretAccessKey"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     azureblob:
       # -- Enable Azure Blob Storage backend
@@ -229,6 +234,8 @@ config:
         existingSecret: ""
         # -- Key in the existing secret containing the SAS token
         secretKey: "sasToken"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     googleCloudStorage:
       # -- Enable Google Cloud Storage backend
@@ -245,6 +252,8 @@ config:
         existingSecret: ""
         # -- Key in the existing secret containing the private key (in PEM format)
         secretKey: "private.key"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     b2:
       # -- Enable Backblaze B2 backend
@@ -259,6 +268,8 @@ config:
         existingSecret: ""
         # -- Key in the existing secret containing the application key
         secretKey: "applicationKey"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     openstackSwift:
       # -- Enable OpenStack Swift backend
@@ -279,6 +290,8 @@ config:
         secretKey: "password"
       # -- Region
       region: ""
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
     rackspaceCloudfiles:
       # -- Enable Rackspace Cloud Files backend
@@ -295,6 +308,8 @@ config:
         existingSecret: ""
         # -- Key in the existing secret containing the API key
         secretKey: "apiKey"
+      # -- Buckets routed to this backend (S3Proxy bucket-locator; glob patterns supported). Only relevant when multiple backends are enabled; a bucket matching no backend's list falls through to the first-enabled backend.
+      bucketLocators: []
 
 persistence:
   # -- Enable persistence using PVC

--- a/ci/functional/assert-routing.sh
+++ b/ci/functional/assert-routing.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Multi-backend routing assertion for the s3proxy functional test.
+#
+# Writes one bucket per backend THROUGH s3proxy (smoke-s3-*, smoke-az-*,
+# smoke-fs-*) and proves each object physically landed on its INTENDED backend by
+# querying that backend's native store directly:
+#   * s3         -> MinIO (S3 API)       : bucket+object present in MinIO.
+#   * azureblob  -> Azurite (Azure API)  : container+blob present in Azurite.
+#   * filesystem -> (no external store)  : absent from MinIO AND Azurite.
+# It also cross-checks that no bucket leaks into another backend's store, i.e.
+# routing is EXCLUSIVE — this is what the old test missed (every bucket silently
+# landed on the single default backend, so it passed without exercising routing).
+#
+# Assumes the multi-backend release is installed with MinIO + Azurite mocks in
+# the same namespace (ci/functional/mocks/{minio,azurite}.yaml) and the values in
+# ci/functional/values/multi-backend.yaml. Requires kubectl, aws and az on PATH.
+#
+# Usage: assert-routing.sh RELEASE NAMESPACE
+set -euo pipefail
+
+RELEASE="${1:?release name required}"
+NAMESPACE="${2:?namespace required}"
+
+# Fixed CI credentials (match multi-backend.yaml + the mock manifests).
+S3P_ID=test-access-key
+S3P_SECRET=test-secret-key
+MINIO_ID=minioadmin
+MINIO_SECRET=minioadmin
+AZ_ACCOUNT=devstoreaccount1
+AZ_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+
+TS=$(date +%s)
+B_S3="smoke-s3-${TS}"
+B_AZ="smoke-az-${TS}"
+B_FS="smoke-fs-${TS}"
+
+S3P_PORT=9900
+MINIO_PORT=9901
+AZ_PORT=9902
+SRC="$(mktemp)"
+DL="$(mktemp)"
+PIDS=""
+
+# AWS CLI defaults that S3Proxy / jclouds S3-compatible backends need:
+# path-style addressing over an IP endpoint, and no default CRC checksums
+# (AWS CLI v2.23+) which the backends answer with NotImplemented.
+export AWS_EC2_METADATA_DISABLED=true
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+export AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
+aws configure set default.s3.addressing_style path
+
+cleanup() {
+  # Best-effort: remove the test buckets through s3proxy, then kill forwards.
+  for b in "$B_S3" "$B_AZ" "$B_FS"; do
+    s3p s3 rm "s3://${b}/obj.txt" >/dev/null 2>&1 || true
+    s3p s3api delete-bucket --bucket "$b" >/dev/null 2>&1 || true
+  done
+  for p in $PIDS; do kill "$p" 2>/dev/null || true; done
+  rm -f "$SRC" "$DL"
+}
+trap cleanup EXIT
+
+pf() { # pf <target> <local-port> <remote-port>
+  kubectl -n "$NAMESPACE" port-forward "$1" "$2:$3" >"/tmp/pf-$2.log" 2>&1 &
+  PIDS="$PIDS $!"
+}
+
+wait_tcp() { # wait_tcp <url>
+  for _ in $(seq 1 30); do
+    if curl -s -o /dev/null "$1"; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+s3p() { # AWS CLI against s3proxy (client creds)
+  AWS_ACCESS_KEY_ID="$S3P_ID" AWS_SECRET_ACCESS_KEY="$S3P_SECRET" \
+    aws --endpoint-url "http://127.0.0.1:${S3P_PORT}" --region us-east-1 "$@"
+}
+minio() { # AWS CLI against MinIO directly (mock creds)
+  AWS_ACCESS_KEY_ID="$MINIO_ID" AWS_SECRET_ACCESS_KEY="$MINIO_SECRET" \
+    aws --endpoint-url "http://127.0.0.1:${MINIO_PORT}" --region us-east-1 "$@"
+}
+AZ_CONN="DefaultEndpointsProtocol=http;AccountName=${AZ_ACCOUNT};AccountKey=${AZ_KEY};BlobEndpoint=http://127.0.0.1:${AZ_PORT}/${AZ_ACCOUNT};"
+azc() { az "$@" --connection-string "$AZ_CONN"; }
+
+echo "==> Waiting for deploy/${RELEASE}"
+kubectl -n "$NAMESPACE" rollout status "deploy/${RELEASE}" --timeout=120s
+
+echo "==> Port-forwarding s3proxy / minio / azurite"
+pf "svc/${RELEASE}" "$S3P_PORT" 9000
+pf "svc/minio" "$MINIO_PORT" 9000
+pf "svc/azurite" "$AZ_PORT" 10000
+wait_tcp "http://127.0.0.1:${S3P_PORT}"  || { echo "ERROR: s3proxy unreachable" >&2; exit 1; }
+wait_tcp "http://127.0.0.1:${MINIO_PORT}/minio/health/live" || wait_tcp "http://127.0.0.1:${MINIO_PORT}" || { echo "ERROR: minio unreachable" >&2; exit 1; }
+# Azurite has no plain-GET health page; give the forward a moment to accept.
+sleep 3
+
+echo "hello-multibackend ${TS}" > "$SRC"
+
+# 1) Write one object per backend through s3proxy and round-trip each.
+for b in "$B_S3" "$B_AZ" "$B_FS"; do
+  echo "==> [$b] create + put + get via s3proxy"
+  s3p s3api create-bucket --bucket "$b"
+  s3p s3 cp "$SRC" "s3://${b}/obj.txt"
+  s3p s3 cp "s3://${b}/obj.txt" "$DL"
+  cmp "$SRC" "$DL"
+  echo "    round-trip OK"
+done
+
+# 2) s3 bucket must live in MinIO; az/fs must NOT.
+echo "==> MinIO must hold ${B_S3} only"
+minio s3api head-bucket --bucket "$B_S3"
+minio s3 ls "s3://${B_S3}/obj.txt" >/dev/null || { echo "FAIL: object missing in MinIO for ${B_S3}" >&2; exit 1; }
+if minio s3api head-bucket --bucket "$B_AZ" >/dev/null 2>&1; then echo "FAIL: ${B_AZ} leaked into MinIO" >&2; exit 1; fi
+if minio s3api head-bucket --bucket "$B_FS" >/dev/null 2>&1; then echo "FAIL: ${B_FS} leaked into MinIO" >&2; exit 1; fi
+
+# 3) azureblob container must live in Azurite; s3/fs must NOT.
+echo "==> Azurite must hold ${B_AZ} only"
+azc storage container show --name "$B_AZ" >/dev/null || { echo "FAIL: ${B_AZ} container missing in Azurite" >&2; exit 1; }
+azc storage blob show --container-name "$B_AZ" --name obj.txt >/dev/null || { echo "FAIL: blob missing in Azurite for ${B_AZ}" >&2; exit 1; }
+if azc storage container show --name "$B_S3" >/dev/null 2>&1; then echo "FAIL: ${B_S3} leaked into Azurite" >&2; exit 1; fi
+if azc storage container show --name "$B_FS" >/dev/null 2>&1; then echo "FAIL: ${B_FS} leaked into Azurite" >&2; exit 1; fi
+
+# 4) filesystem: proven by elimination (absent from both external stores above)
+#    plus a successful s3proxy round-trip.
+echo "==> ${B_FS} absent from MinIO and Azurite -> served by the filesystem backend"
+
+echo "✅ Multi-backend routing verified: smoke-s3 -> MinIO, smoke-az -> Azurite, smoke-fs -> filesystem (routing is exclusive)"

--- a/ci/functional/mocks/azurite.yaml
+++ b/ci/functional/mocks/azurite.yaml
@@ -27,6 +27,10 @@ spec:
             - 0.0.0.0
             - --blobPort
             - "10000"
+            # Accept any storage API version. The assertion's `az` CLI on the CI
+            # runner sends a newer x-ms-version than this Azurite image knows,
+            # which it would otherwise reject with InvalidHeaderValue.
+            - --skipApiVersionCheck
           ports:
             - name: blob
               containerPort: 10000

--- a/ci/functional/values/azureblob.yaml
+++ b/ci/functional/values/azureblob.yaml
@@ -2,10 +2,10 @@
 # mock (ci/functional/mocks/azurite.yaml -> Service "azurite:10000") using
 # Azurite's well-known devstoreaccount1 credentials.
 #
-# NOTE: expected to FAIL against current main until DND-1416 is fixed — the chart
-# emits jclouds.azureblob.endpoint (typo) instead of jclouds.endpoint, so the
-# custom Azurite endpoint is ignored. This leg runs non-blocking in CI and is a
-# live demonstration that the functional test catches the regression.
+# Uses the azureblob-sdk provider (Azure SDK), which signs correctly against
+# Azurite and any custom endpoint; the legacy "azureblob" provider mis-signs the
+# SharedKey and Azurite rejects it with 403. Relies on the jclouds.endpoint fix
+# (previously the chart emitted the jclouds.azureblob.endpoint typo).
 config:
   auth:
     type: aws-v4
@@ -16,7 +16,7 @@ config:
       enabled: false
     azureblob:
       enabled: true
-      provider: azureblob
+      provider: azureblob-sdk
       account: devstoreaccount1
       endpoint: http://azurite:10000/devstoreaccount1
       key:

--- a/ci/functional/values/multi-backend.yaml
+++ b/ci/functional/values/multi-backend.yaml
@@ -1,23 +1,13 @@
 # Functional-test values: THREE backends enabled in one release — s3 (MinIO
-# mock), azureblob (Azurite mock) and filesystem (PVC) — to exercise the chart's
-# multi-backend wiring end-to-end. The workflow round-trips one bucket per
-# backend (smoke-s3-*/smoke-az-*/smoke-fs-*).
-#
-# NOTE: expected to FAIL against current main — runs NON-BLOCKING (soft_fail)
-# until the chart can actually serve multiple backends:
-#   * DND-1442: filesystem emits no jclouds.identity/jclouds.credential, so
-#     s3proxy refuses to start at all.
-#   * DND-1416: azureblob emits jclouds.azureblob.endpoint instead of
-#     jclouds.endpoint, so the Azurite mock endpoint is ignored.
-#   * secret.yaml's if/else-if emits only the FIRST enabled backend's
-#     jclouds.credential (s3 here), and the merge initContainer appends that
-#     same secret.properties to EVERY backend's properties file — azureblob
-#     ends up with MinIO's credential.
-#   * All backend properties files share one s3proxy.endpoint, and the chart
-#     renders the same (global) bucket-locator list into each of them, so there
-#     is no way to route a bucket to a specific backend yet. Needs per-backend
-#     s3proxy.bucket-locator support (e.g. config.backends.<name>.bucketLocators
-#     emitting s3proxy.bucket-locator.N per properties file).
+# mock), azureblob (Azurite mock) and filesystem (PVC) — with per-backend
+# bucket-locator routing. ci/functional/assert-routing.sh writes one bucket per
+# backend through s3proxy (smoke-s3-*/smoke-az-*/smoke-fs-*) and verifies each
+# object physically lands on its intended backend:
+#   * smoke-s3-*  -> s3        -> witnessed directly in MinIO (S3 API)
+#   * smoke-az-*  -> azureblob -> witnessed directly in Azurite (Azure Blob API)
+#   * smoke-fs-*  -> filesystem-> absent from MinIO and Azurite (by elimination)
+# and that no bucket leaks into another backend's store (guards the previous
+# "everything lands on the default backend" false green).
 config:
   auth:
     type: aws-v4
@@ -28,6 +18,8 @@ config:
       enabled: true
       nio2: true
       basedir: /data/s3proxy
+      bucketLocators:
+        - "smoke-fs-*"
     s3:
       enabled: true
       aws: false
@@ -36,13 +28,19 @@ config:
       accessKeyID: minioadmin
       secretAccessKey:
         value: minioadmin
+      bucketLocators:
+        - "smoke-s3-*"
     azureblob:
       enabled: true
-      provider: azureblob
+      # azureblob-sdk (Azure SDK) signs correctly against Azurite and any custom
+      # endpoint; the legacy "azureblob" provider mis-signs SharedKey → 403.
+      provider: azureblob-sdk
       account: devstoreaccount1
       endpoint: http://azurite:10000/devstoreaccount1
       key:
         value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+      bucketLocators:
+        - "smoke-az-*"
 persistence:
   enabled: true
   size: 1Gi


### PR DESCRIPTION
## Why

The `multi-backend` functional leg enabled s3 + azureblob + filesystem in one release but only ever exercised one backend. The chart had no way to route a bucket to a specific backend, so S3Proxy served every bucket from the first (default) backend; the leg passed green without ever touching azureblob or s3. This change makes it actually route to and verify each backend.

## Chart changes

- **Per-backend bucket-locator.** `s3proxy.bucket-locator.N` was emitted in the shared config block, so the same global list was copied into every backend's properties file. S3Proxy de-dupes locators across `--properties` files (first file wins), so only the first backend ever honored them. Now each backend renders its own locators from `config.backends.<name>.bucketLocators`, and the global `config.buckets.locator` is removed.
- **Per-backend credentials.** The single shared `secret.properties` emitted only the first-enabled backend's `jclouds.credential` and was appended to every backend file, so azureblob got s3's credential. It is replaced with `secret-common.properties` (client auth, appended to all) plus per-backend `secret-<name>.properties`; the merge initContainer appends common plus the matching backend secret, so each backend gets only its own credential. This also fixes a latent GCS `jclouds.credential=jclouds.credential=` double-prefix.
- **azureblob endpoint.** Emit the provider-agnostic `jclouds.endpoint` (previously the `jclouds.azureblob.endpoint` typo) and render the computed default endpoint when only `account` is set.

## Test changes

- `ci/functional/values/multi-backend.yaml` routes `smoke-s3-*`/`smoke-az-*`/`smoke-fs-*` to their backends. azureblob uses the `azureblob-sdk` provider, which signs correctly against Azurite; the legacy `azureblob` provider mis-signs SharedKey and Azurite returns 403 (verified on kind).
- New `ci/functional/assert-routing.sh`: it writes one bucket per backend through s3proxy and verifies each object physically lands on its intended backend (MinIO via the S3 API for s3, Azurite via the `az` CLI for azureblob, filesystem by elimination), and that no bucket leaks into another backend's store.
- The Azurite mock runs with `--skipApiVersionCheck`. The assertion's `az` CLI on the CI runner sends a newer `x-ms-version` than the pinned Azurite image knows, which it would otherwise reject (InvalidHeaderValue). The s3proxy azureblob-sdk path is unaffected.
- `.github/workflows/functional-test.yaml`: the `multi-backend` and `azureblob` legs are now hard gates (all `soft_fail` removed); multi-backend runs the routing assertion instead of the plain round-trip.

## Verification (local kind, end-to-end)

- **multi-backend**: routing is exclusive. `smoke-s3` goes to MinIO, `smoke-az` to Azurite, `smoke-fs` to filesystem, with no cross-leaks.
- **azureblob-only**, **s3-only**, **filesystem-only**: all pass (the secret-merge rework does not regress single-backend deployments).
- `helm lint`, `kubeconform -strict` (k8s 1.29, all test-values), `actionlint`, `shellcheck`: clean.

## Notes

- No `Chart.yaml` version bump (handled separately), so `verify-version` fails by design for now.
- The repo's helm-docs action regenerates the root `README.md` from `README.md.gotmpl` on the PR; only the template is edited here.
- The chart default azureblob `provider` is left as `azureblob`. Whether to make `azureblob-sdk` the default is left to the dedicated azureblob ticket (DND-1416); this PR only sets it in the functional test values.
