### PR TITLE
[DND-1416] Add optional azureblob regions (jclouds.regions) for bucket creation

### DIFF
--- a/charts/s3proxy/templates/configmap.yaml
+++ b/charts/s3proxy/templates/configmap.yaml
@@ -142,6 +142,11 @@ data:
   {{- if or .Values.config.backends.azureblob.endpoint .Values.config.backends.azureblob.account }}
     jclouds.endpoint={{ .Values.config.backends.azureblob.endpoint | default (printf "https://%s.blob.core.windows.net" .Values.config.backends.azureblob.account) }}
   {{- end }}
+  {{- if .Values.config.backends.azureblob.regions }}
+    # Required by the azureblob-sdk provider on real Azure to create buckets
+    # (otherwise "no jclouds.regions configured" -> InvalidLocationConstraint).
+    jclouds.regions={{ .Values.config.backends.azureblob.regions }}
+  {{- end }}
   {{- if .Values.config.backends.azureblob.account }}
     jclouds.identity={{ .Values.config.backends.azureblob.account }}
   {{- end }}

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -226,6 +226,8 @@ config:
       # -- (string) Azure endpoint
       # @default -- `https://{{ .Values.config.backends.azureblob.account }}.blob.core.windows.net`
       endpoint:
+      # -- jclouds region(s) for the backend, emitted as `jclouds.regions=`. The azureblob-sdk provider requires this on real Azure to create buckets (without it `aws s3 mb` fails with InvalidLocationConstraint / "no jclouds.regions configured"). Comma-separated for multiple. Not needed against Azurite. Leave empty to omit.
+      regions: ""
       # -- SAS token configuration
       sasToken:
         # -- SAS token value


### PR DESCRIPTION
## Why

Completes DND-1416 item 2 (GH issue #15). The `azureblob-sdk` provider on real Azure needs `jclouds.regions` to create buckets; without it `aws s3 mb` fails with `InvalidLocationConstraint` ("no jclouds.regions configured for provider azureblob-sdk"). The chart had no way to set it.

Items 1 (endpoint property typo) and 3 (default-endpoint guard) already landed via PR #22.

## Change

- New optional value `config.backends.azureblob.regions`. When set, the azureblob backend properties emit `jclouds.regions=<value>` (comma-separated for multiple). When empty (the default), nothing is emitted, so Azurite and every other backend are unaffected.

## Verification

- Render: `regions` set emits `jclouds.regions=`; empty omits it.
- `helm lint` and `kubeconform -strict` (k8s 1.29, all test-values): clean.
- kind smoke: `azureblob-sdk` + `jclouds.regions` still round-trips create/put/get against Azurite (the knob wires through without breaking the working path).

## Not covered here

- **Real-Azure validation.** The actual `InvalidLocationConstraint` fix (and the correct default region) needs a live Azure backend, which isn't available in CI or the agentro environment. This PR provides the knob and confirms it renders and wires through against Azurite; closing issue #15 should wait on a real-Azure `aws s3 mb` check with `regions` set.
- **Chart default `provider`** stays `azureblob` (unchanged); whether to make `azureblob-sdk` the default is deferred.

## Notes

- No `Chart.yaml` version bump (deferred, handled separately with the other accumulated chart changes), so `verify-version` fails by design for now.
- The repo's helm-docs action regenerates the root `README.md`; only `values.yaml` (which drives the values table) is edited here.
