### PR TITLE
[DND-1443] HPA autoscaling/v2 + helm-polish cleanup, LICENSE, and 0.1.0 release

### DIFF
--- a/.github/workflows/lint-render.yaml
+++ b/.github/workflows/lint-render.yaml
@@ -35,6 +35,7 @@ jobs:
           - test-values/rackspace.yaml
           - test-values/multi-backend.yaml
           - test-values/ingress.yaml
+          - test-values/autoscaling.yaml
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+Copyright (c) Comet ML, Inc
+                   
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Comet ML, Inc
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/s3proxy/templates/_helpers.tpl
+++ b/charts/s3proxy/templates/_helpers.tpl
@@ -1,11 +1,11 @@
-{{/*
+{{- /*
 Expand the name of the chart.
 */}}
 {{- define "s3proxy.name" -}}
   {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
+{{- /*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -23,26 +23,26 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
 {{- end }}
 
-{{/*
+{{- /*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "s3proxy.chart" -}}
   {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
+{{- /*
 Common labels
 */}}
 {{- define "s3proxy.labels" -}}
 helm.sh/chart: {{ include "s3proxy.chart" . }}
 {{ include "s3proxy.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{/*
+{{- /*
 Selector labels
 */}}
 {{- define "s3proxy.selectorLabels" -}}
@@ -50,7 +50,7 @@ app.kubernetes.io/name: {{ include "s3proxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{/*
+{{- /*
 Create the name of the service account to use
 */}}
 {{- define "s3proxy.serviceAccountName" -}}

--- a/charts/s3proxy/templates/configmap.yaml
+++ b/charts/s3proxy/templates/configmap.yaml
@@ -69,7 +69,7 @@ metadata:
 data:
 {{- if .Values.config.backends.filesystem.enabled }}
   backend-filesystem.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Filesystem backend configuration
   {{- if .Values.config.backends.filesystem.nio2 }}
@@ -89,7 +89,7 @@ data:
 
 {{- if .Values.config.backends.transient.enabled }}
   backend-transient.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Transient backend configuration
   {{- if .Values.config.backends.transient.nio2 }}
@@ -108,7 +108,7 @@ data:
 
 {{- if .Values.config.backends.s3.enabled }}
   backend-s3.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # S3 backend configuration
   {{- if .Values.config.backends.s3.aws }}
@@ -135,7 +135,7 @@ data:
 
 {{- if .Values.config.backends.azureblob.enabled }}
   backend-azureblob.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Azure Blob backend configuration
     jclouds.provider={{ .Values.config.backends.azureblob.provider }}
@@ -160,7 +160,7 @@ data:
 
 {{- if .Values.config.backends.googleCloudStorage.enabled }}
   backend-google-cloud-storage.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Google Cloud Storage backend configuration
     jclouds.provider=google-cloud-storage
@@ -184,7 +184,7 @@ data:
 
 {{- if .Values.config.backends.b2.enabled }}
   backend-b2.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Backblaze B2 backend configuration
     jclouds.provider=b2
@@ -201,7 +201,7 @@ data:
 
 {{- if .Values.config.backends.openstackSwift.enabled }}
   backend-openstack-swift.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # OpenStack Swift backend configuration
     jclouds.provider=openstack-swift
@@ -224,7 +224,7 @@ data:
 
 {{- if .Values.config.backends.rackspaceCloudfiles.enabled }}
   backend-rackspace-cloudfiles.properties: |-
-{{ include "s3proxy.main.config" . | nindent 4 }}
+    {{- include "s3proxy.main.config" . | nindent 4 }}
 
     # Rackspace Cloud Files backend configuration
   {{- if eq .Values.config.backends.rackspaceCloudfiles.region "uk" }}

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
 {{- end }}
       labels:
         {{- include "s3proxy.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+{{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+{{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/s3proxy/templates/hpa.yaml
+++ b/charts/s3proxy/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "s3proxy.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/s3proxy/templates/secret.yaml
+++ b/charts/s3proxy/templates/secret.yaml
@@ -25,16 +25,16 @@ stringData:
     jclouds.credential={{ .Values.config.backends.s3.secretAccessKey.value }}
 {{- end }}
 {{- if .Values.config.backends.azureblob.enabled }}
-{{- if or .Values.config.backends.azureblob.key.value .Values.config.backends.azureblob.sasToken.value }}
+  {{- if or .Values.config.backends.azureblob.key.value .Values.config.backends.azureblob.sasToken.value }}
   secret-azureblob.properties: |
     # Azure Blob backend credentials
-{{- if .Values.config.backends.azureblob.key.value }}
+    {{- if .Values.config.backends.azureblob.key.value }}
     jclouds.credential={{ .Values.config.backends.azureblob.key.value }}
-{{- end }}
-{{- if .Values.config.backends.azureblob.sasToken.value }}
+    {{- end }}
+    {{- if .Values.config.backends.azureblob.sasToken.value }}
     jclouds.azureblob.sas={{ .Values.config.backends.azureblob.sasToken.value }}
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if and .Values.config.backends.googleCloudStorage.enabled .Values.config.backends.googleCloudStorage.privateKey.value }}
   secret-google-cloud-storage.properties: |

--- a/test-values/autoscaling.yaml
+++ b/test-values/autoscaling.yaml
@@ -1,0 +1,25 @@
+# Render/lint scenario: HorizontalPodAutoscaler enabled, exercising both the CPU
+# and memory target metrics. kubeconform validates the rendered HPA against the
+# Kubernetes schema, so this scenario is the gate that keeps hpa.yaml on the
+# supported autoscaling/v2 API (the removed autoscaling/v2beta1 was rejected by
+# kubeconform on k8s >= 1.25 — DND-1443).
+config:
+  auth:
+    type: aws-v4
+    identity: test-access-key
+    secret: test-secret-key
+  backends:
+    filesystem:
+      enabled: true
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 75
+persistence:
+  enabled: false
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi


### PR DESCRIPTION
This PR started as the DND-1443 HPA fix and now also carries a chart lint cleanup, a LICENSE, and the version bump that reconciles the recently merged chart changes. Four self-contained commits:

## 1. DND-1443: migrate `hpa.yaml` to `autoscaling/v2`

`hpa.yaml` emitted `apiVersion: autoscaling/v2beta1`, removed in Kubernetes 1.25. On any cluster at or above 1.25, `autoscaling.enabled=true` produced an HPA the API server rejects, and `kubeconform -strict` failed it. Surfaced by the lint-render check added in DND-1417.

- `hpa.yaml`: `autoscaling/v2beta1` to `autoscaling/v2`, with the metrics migrated to the v2 shape (`spec.metrics[].resource.target.type: Utilization` + `averageUtilization`, replacing `targetAverageUtilization`). Values API unchanged.
- New `test-values/autoscaling.yaml` (HPA enabled, CPU + memory targets), registered in the `lint-render` matrix, so kubeconform now validates the HPA on every PR. Previously no gated scenario enabled autoscaling, which is why the bug shipped. `helm-diff` globs `test-values/*.yaml` and picks it up too.

## 2. helm-polish template style cleanup

Ran `helm-polish` (a `helm lint` wrapper plus opinionated style rules) and cleared all findings in the default rule set (0 errors; `--strict` exits 0).

- `HP1101`: template comments use leading-dash trimming (`{{- /*`) in `_helpers.tpl`.
- `HP1105`/`HP1106`: the per-backend `include ... | nindent 4` lines in `configmap.yaml` use a leading dash and are indented to match the nindent.
- `HP1110`: control-flow directives (`if`/`with`/`end`) indented by control-flow nesting depth in `_helpers.tpl`, `deployment.yaml`, and `secret.yaml`.

These are template-source style only. The rendered manifests are unchanged except that each backend properties block loses a leading blank line (from the nindent dash-trim), which recomputes the `checksum/config` annotation. All reindents are `{{- }}` trims and produce no output change. The one remaining helm-polish item is `HP0104` "icon is recommended" (info), left as-is because it needs an icon asset rather than a code fix.

## 3. Add LICENSE (Apache-2.0)

The repo had no top-level LICENSE. Copied the Apache License 2.0 (with the `Copyright (c) Comet ML, Inc` header) verbatim from `comet-ml/common-helm-chart`, matching the other Comet helm charts. Repo-root only, not under `charts/s3proxy/`, so the packaged chart is unaffected.

## 4. Bump chart version 0.0.8 to 0.1.0

Reconciles the chart changes that merged without a version bump (DND-1442 in #21, azureblob endpoint + multi-backend routing in #22) together with this PR's changes. Clears the `verify-version` gate and cuts a `0.1.0` release on merge. Minor bump: new `azureblob.regions` value and per-backend `bucketLocators`, no breaking changes.

## Verification

- `helm-polish`: 0 errors (`--strict` exits 0); `helm lint` clean.
- `kubeconform -strict` (k8s 1.29): valid across all `test-values`, including the new autoscaling scenario (HPA validated).
- Render diff vs base is only the cosmetic blank-line/checksum change described above.
- CI: all functional legs (s3, filesystem, transient, azureblob, multi-backend), all lint-render legs, render-diff, preview-readme, and `verify-version` pass.

## Note on sequencing

PR #23 (azureblob `regions`) also changes the chart without its own bump. Once this PR merges and releases `0.1.0`, #23 will need its own bump (for example `0.1.1`) or a rebase onto this branch before its `verify-version` passes.
